### PR TITLE
[Don't Merge] Runs example against stage

### DIFF
--- a/experiments/examples/experiment.rs
+++ b/experiments/examples/experiment.rs
@@ -3,9 +3,18 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use anyhow::Result;
-use experiments::{AppContext, Experiments};
+use experiments::{AppContext, Config, Experiments};
 fn main() -> Result<()> {
-    let exp = Experiments::new(AppContext::default(), "../target/mydb", None);
-    exp.get_experiments();
+    viaduct_reqwest::use_reqwest_backend();
+    let config = Config {
+        _server_url: Some("https://settings.stage.mozaws.net".to_string()),
+        _bucket_name: Some("main".to_string()),
+        _collection_name: Some("messaging-experiments".to_string()),
+        uuid: None,
+    };
+    let exp = Experiments::new(AppContext::default(), "../target/mydb", Some(config)).unwrap();
+    exp.get_experiments().iter().for_each(|exp| {
+        println!("Experiment: {}", exp.id);
+    });
     Ok(())
 }

--- a/experiments/src/config.rs
+++ b/experiments/src/config.rs
@@ -14,6 +14,7 @@
 /// - `uuid`: A custom user uuid that would otherwise be generated or loaded from persisted storage
 /// - `collection_name`: The name of the collection on the server
 /// - `bucket_name`: The name of the bucket containing the collection on the server
+#[derive(Debug, Clone)]
 pub struct Config {
     pub _server_url: Option<String>,
     pub uuid: Option<String>,

--- a/experiments/src/error.rs
+++ b/experiments/src/error.rs
@@ -21,6 +21,12 @@ pub enum Error {
     EvaluationError,
     #[error("Invalid Expression")]
     InvalidExpression,
+    #[error("Error parsing Url: {0}")]
+    UrlParseError(#[from] url::ParseError),
+    #[error("Error sending request: {0}")]
+    RequestError(#[from] viaduct::Error),
+    #[error("Server responded with an error: {0}")]
+    ResponseError(String),
 }
 
 // This can be replaced with #[from] in the enum definition

--- a/experiments/src/http_client.rs
+++ b/experiments/src/http_client.rs
@@ -7,9 +7,15 @@
 //! Working on the real Nimbus schema.
 
 use super::Experiment;
-use anyhow::Result;
+use crate::error::{Error, Result};
+use crate::Config;
+use serde_derive::*;
 use url::Url;
 use viaduct::{status_codes, Request, Response};
+
+const DEFAULT_BASE_URL: &str = "https://settings.stage.mozaws.net"; // TODO: Replace this with prod
+const DEFAULT_BUCKET_NAME: &str = "main";
+const DEFAULT_COLLECTION_NAME: &str = "messaging-experiment";
 
 // Making this a trait so that we can mock those later.
 pub(crate) trait SettingsClient {
@@ -17,20 +23,47 @@ pub(crate) trait SettingsClient {
     fn get_experiments(&self) -> Result<Vec<Experiment>>;
 }
 
+#[derive(Debug)]
 pub struct Client {
     base_url: Url,
-    collection_name: String,
     bucket_name: String,
+    collection_name: String,
+}
+
+#[derive(Deserialize)]
+struct ExperimentResponse {
+    data: Vec<Experiment>,
 }
 
 impl Client {
     #[allow(unused)]
-    pub fn new(base_url: Url, collection_name: String, bucket_name: String) -> Self {
-        Self {
+    pub fn new(config: Option<Config>) -> Result<Self> {
+        let (base_url, bucket_name, collection_name) = Self::get_params_from_config(config)?;
+        Ok(Self {
             base_url,
-            collection_name,
             bucket_name,
-        }
+            collection_name,
+        })
+    }
+
+    fn get_params_from_config(config: Option<Config>) -> Result<(Url, String, String)> {
+        Ok(match config {
+            Some(config) => {
+                let base_url = config._server_url.unwrap_or(DEFAULT_BASE_URL.to_string());
+                let bucket_name = config
+                    ._bucket_name
+                    .unwrap_or(DEFAULT_BUCKET_NAME.to_string());
+                let collection_name = config
+                    ._collection_name
+                    .unwrap_or(DEFAULT_COLLECTION_NAME.to_string());
+                (Url::parse(&base_url)?, bucket_name, collection_name)
+            }
+            None => (
+                Url::parse(DEFAULT_BASE_URL)?,
+                DEFAULT_BUCKET_NAME.to_string(),
+                DEFAULT_COLLECTION_NAME.to_string(),
+            ),
+        })
     }
 
     fn make_request(&self, request: Request) -> Result<Response> {
@@ -38,7 +71,7 @@ impl Client {
         if resp.is_success() || resp.status == status_codes::NOT_MODIFIED {
             Ok(resp)
         } else {
-            anyhow::bail!("Error in request: {}", resp.text())
+            Err(Error::ResponseError(resp.text().to_string()))
         }
     }
 }
@@ -55,8 +88,8 @@ impl SettingsClient for Client {
         );
         let url = self.base_url.join(&path)?;
         let req = Request::get(url);
-        let resp = self.make_request(req)?.json::<Vec<Experiment>>()?;
-        Ok(resp)
+        let resp = self.make_request(req)?.json::<ExperimentResponse>()?;
+        Ok(resp.data)
     }
 }
 
@@ -70,51 +103,54 @@ mod tests {
     fn test_get_experiments_from_schema() {
         viaduct_reqwest::use_reqwest_backend();
         let body = r#"
-        [
-            {
-                "id": "ABOUTWELCOME-PULL-FACTOR-REINFORCEMENT-76-RELEASE",
-                "enabled": true,
-                "filter_expression": "(env.version >= '76.' && env.version < '77.' && env.channel == 'release' && !(env.telemetry.main.environment.profile.creationDate < ('2020-05-13'|date / 1000 / 60 / 60 / 24))) || (locale == 'en-US' && [userId, \"aboutwelcome-pull-factor-reinforcement-76-release\"]|bucketSample(0, 2000, 10000) && (!('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue) || 'bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77' in activeExperiments))",
-                "arguments": {
-                    "slug": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
-                    "userFacingName": "About:Welcome Pull Factor Reinforcement",
-                    "userFacingDescription": "4 branch experiment different variants of about:welcome with a goal of testing new experiment framework and get insights on whether reinforcing pull-factors improves retention. Test deployment of multiple branches using new experiment framework",
-                    "isEnrollmentPaused": true,
-                    "active": true,
-                    "bucketConfig": {
-                        "randomizationUnit": "normandy_id",
-                        "namespace": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
-                        "start": 0,
-                        "count": 2000,
-                        "total": 10000
-                    },
-                    "startDate": "2020-06-17T23:20:47.230Z",
-                    "endDate": null,
-                    "proposedDuration": 28,
-                    "proposedEnrollment": 7,
-                    "referenceBranch": "control",
-                    "features": [],
-                    "branches": [
-                        { "slug": "control", "ratio": 1, "value": {}, "group": ["cfr"] },
-                        { "slug": "treatment-variation-b", "ratio": 1, "value": {} }
-                    ]
+        {
+            "data":  [
+                {
+                    "id": "ABOUTWELCOME-PULL-FACTOR-REINFORCEMENT-76-RELEASE",
+                    "enabled": true,
+                    "filter_expression": "(env.version >= '76.' && env.version < '77.' && env.channel == 'release' && !(env.telemetry.main.environment.profile.creationDate < ('2020-05-13'|date / 1000 / 60 / 60 / 24))) || (locale == 'en-US' && [userId, \"aboutwelcome-pull-factor-reinforcement-76-release\"]|bucketSample(0, 2000, 10000) && (!('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue) || 'bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77' in activeExperiments))",
+                    "arguments": {
+                        "slug": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
+                        "userFacingName": "About:Welcome Pull Factor Reinforcement",
+                        "userFacingDescription": "4 branch experiment different variants of about:welcome with a goal of testing new experiment framework and get insights on whether reinforcing pull-factors improves retention. Test deployment of multiple branches using new experiment framework",
+                        "isEnrollmentPaused": true,
+                        "active": true,
+                        "bucketConfig": {
+                            "randomizationUnit": "normandy_id",
+                            "namespace": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
+                            "start": 0,
+                            "count": 2000,
+                            "total": 10000
+                        },
+                        "startDate": "2020-06-17T23:20:47.230Z",
+                        "endDate": null,
+                        "proposedDuration": 28,
+                        "proposedEnrollment": 7,
+                        "referenceBranch": "control",
+                        "features": [],
+                        "branches": [
+                            { "slug": "control", "ratio": 1, "value": {}, "group": ["cfr"] },
+                            { "slug": "treatment-variation-b", "ratio": 1, "value": {} }
+                        ]
+                    }
                 }
-            }
-        ]
-          "#;
+            ]
+        }"#;
         let m = mock(
             "GET",
-            "/buckets/main/collections/messaging-collection/records",
+            "/buckets/main/collections/messaging-experiment/records",
         )
         .with_body(body)
         .with_status(200)
         .with_header("content-type", "application/json")
         .create();
-        let http_client = Client::new(
-            Url::parse(&mockito::server_url()).unwrap(),
-            "messaging-collection".to_string(),
-            "main".to_string(),
-        );
+        let config = Config {
+            _server_url: Some(mockito::server_url().to_string()),
+            _collection_name: None,
+            _bucket_name: None,
+            uuid: None,
+        };
+        let http_client = Client::new(Some(config)).unwrap();
         let resp = http_client.get_experiments().unwrap();
         m.expect(1).assert();
         assert_eq!(resp.len(), 1);
@@ -126,25 +162,24 @@ mod tests {
             arguments: ExperimentArguments {
                     slug: "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77".to_string(),
                     user_facing_name: "About:Welcome Pull Factor Reinforcement".to_string(),
-                    user_facing_description: "4 branch experiment different variants of about:welcome with a goal of testing new experiment framework and get insights on whether reinforcing pull-factors improves retention. Test deployment of multiple branches using new experiment framework".to_string(),
+                    user_facing_description: Some("4 branch experiment different variants of about:welcome with a goal of testing new experiment framework and get insights on whether reinforcing pull-factors improves retention. Test deployment of multiple branches using new experiment framework".to_string()),
                     is_enrollment_paused: true,
-                    active: true,
-                    bucket_config: BucketConfig {
+                    active: Some(true),
+                    bucket_config: Some(BucketConfig {
                         randomization_unit: RandomizationUnit::NormandyId,
                         namespace: "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77".to_string(),
                         start: 0,
                         count: 2000,
                         total: 10000
-                    },
-                    start_date: serde_json::from_str("\"2020-06-17T23:20:47.230Z\"").unwrap(),
+                    }),
                     end_date: None,
-                    proposed_duration: 28,
-                    proposed_enrollment: 7,
+                    proposed_duration: Some(28),
+                    proposed_enrollment: Some(7),
                     reference_branch: Some("control".to_string()),
-                    features: vec![],
+                    features: Some(vec![]),
                     branches: vec![
-                        Branch { slug: "control".to_string(), ratio: 1, value: BranchValue {}, group: Some(vec![Group::Cfr]) },
-                        Branch { slug: "treatment-variation-b".to_string(), ratio: 1, value: BranchValue {}, group: None }
+                        Branch { slug: "control".to_string(), ratio: 1, value: Some(BranchValue {}), group: Some(vec![Group::Cfr]) },
+                        Branch { slug: "treatment-variation-b".to_string(), ratio: 1, value: Some(BranchValue {}), group: None }
                     ]
                 },
             targeting: None,


### PR DESCRIPTION
Runs the example against the stage environment. 

`Don't merge` because some experiments on the stage environment don't have some required fields, and to make the example run I changed up our schema to allow for that