### PR TITLE
Skips invalid experiments recieved from the server

### DIFF
--- a/experiments/Cargo.lock
+++ b/experiments/Cargo.lock
@@ -412,11 +412,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "experiments"
 version = "1.0.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "env_logger",
  "hex",
  "jexl-eval",
  "log",
@@ -692,6 +706,15 @@ name = "humansize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e"
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
 
 [[package]]
 name = "hyper"
@@ -1270,6 +1293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1648,6 +1677,15 @@ dependencies = [
  "byteorder",
  "dirs",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2073,6 +2111,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/experiments/Cargo.toml
+++ b/experiments/Cargo.toml
@@ -37,3 +37,4 @@ uniffi_build = { git = "https://github.com/mozilla/uniffi-rs", rev = "686a8ec672
 [dev-dependencies]
 viaduct-reqwest = { git = "https://github.com/mozilla/application-services",  rev = "2478bcf2b48d1867b01e8b7df4f86a69d564d49a"}
 mockito = "0.27"
+env_logger = "0.7"

--- a/experiments/examples/experiment.rs
+++ b/experiments/examples/experiment.rs
@@ -5,7 +5,24 @@
 use anyhow::Result;
 use experiments::{AppContext, Experiments};
 fn main() -> Result<()> {
-    let exp = Experiments::new(AppContext::default(), "../target/mydb", None).unwrap();
-    exp.get_active_experiments();
+    use env_logger::Env;
+    // We set the logging level to be `warn` here, meaning that only
+    // logs of `warn` or higher will be actually be shown, any other
+    // error will be omitted
+    // To manually set the log level, you can set the `RUST_LOG` environment variable
+    // Possible values are "info", "debug", "warn" and "error"
+    // Check [`env_logger`](https://docs.rs/env_logger/) for more details
+    env_logger::from_env(Env::default().default_filter_or("warn")).init();
+    viaduct_reqwest::use_reqwest_backend();
+    let exp = Experiments::new(
+        "messaging-experiments".to_string(),
+        AppContext::default(),
+        "../target/mydb",
+        None,
+    )
+    .unwrap();
+    exp.get_active_experiments()
+        .iter()
+        .for_each(|e| println!("Experiment: {}", e.slug));
     Ok(())
 }

--- a/experiments/src/config.rs
+++ b/experiments/src/config.rs
@@ -12,11 +12,10 @@
 /// Currently includes the following:
 /// - `server_url`: The url for the settings server that would be used to retrieve experiments
 /// - `uuid`: A custom user uuid that would otherwise be generated or loaded from persisted storage
-/// - `collection_name`: The name of the collection on the server
 /// - `bucket_name`: The name of the bucket containing the collection on the server
+#[derive(Debug, Clone)]
 pub struct Config {
     pub server_url: Option<String>,
     pub uuid: Option<String>,
-    pub collection_name: Option<String>,
     pub bucket_name: Option<String>,
 }

--- a/experiments/src/error.rs
+++ b/experiments/src/error.rs
@@ -28,6 +28,14 @@ pub enum Error {
     EmptyRatiosError,
     #[error("Attempt to access an element that is out of bounds")]
     OutOfBoundsError,
+    #[error("Error parsing URL: {0}")]
+    UrlParsingError(#[from] url::ParseError),
+    #[error("Error sending request: {0}")]
+    RequestError(#[from] viaduct::Error),
+    #[error("Error in network response: {0}")]
+    ResponseError(String),
+    #[error("Invalid experiments response recieved")]
+    InvalidExperimentResponse,
 }
 
 // This can be replaced with #[from] in the enum definition

--- a/experiments/src/evaluator.rs
+++ b/experiments/src/evaluator.rs
@@ -131,7 +131,7 @@ pub(crate) fn targeting(expression_statement: &str, ctx: AppContext) -> Result<b
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{BranchValue, BucketConfig, ExperimentArguments, RandomizationUnit};
+    use crate::{BucketConfig, ExperimentArguments, RandomizationUnit};
     #[test]
     fn test_targeting() {
         // Here's our valid jexl statement
@@ -235,13 +235,13 @@ mod tests {
                 slug: "control".to_string(),
                 group: None,
                 ratio: 1,
-                value: BranchValue {},
+                value: None,
             },
             Branch {
                 slug: "blue".to_string(),
                 group: None,
                 ratio: 1,
-                value: BranchValue {},
+                value: None,
             },
         ];
         // 299eed1e-be6d-457d-9e53-da7b1a03f10d maps to the second index
@@ -275,8 +275,8 @@ mod tests {
                     total: 10000,
                 },
                 features: Default::default(),
-                branches: vec![Branch {slug: "control".to_string(), group: None, ratio: 1, value: BranchValue {}},
-                Branch {slug: "blue".to_string(), group: None, ratio: 1, value: BranchValue {}}],
+                branches: vec![Branch {slug: "control".to_string(), group: None, ratio: 1, value: None},
+                Branch {slug: "blue".to_string(), group: None, ratio: 1, value: None}],
                 start_date: serde_json::from_str("\"2020-06-17T23:20:47.230Z\"").unwrap(),
                 end_date: Default::default(),
                 proposed_duration: Default::default(),

--- a/experiments/src/http_client.rs
+++ b/experiments/src/http_client.rs
@@ -7,9 +7,13 @@
 //! Working on the real Nimbus schema.
 
 use super::Experiment;
-use anyhow::Result;
+use crate::config::Config;
+use crate::error::{Error, Result};
 use url::Url;
 use viaduct::{status_codes, Request, Response};
+
+const DEFAULT_BASE_URL: &str = "https://settings.stage.mozaws.net"; // TODO: Replace this with prod
+const DEFAULT_BUCKET_NAME: &str = "main";
 
 // Making this a trait so that we can mock those later.
 pub(crate) trait SettingsClient {
@@ -25,12 +29,31 @@ pub struct Client {
 
 impl Client {
     #[allow(unused)]
-    pub fn new(base_url: Url, collection_name: String, bucket_name: String) -> Self {
-        Self {
+    pub fn new(collection_name: &str, config: Option<Config>) -> Result<Self> {
+        let (base_url, bucket_name) = Self::get_params_from_config(config)?;
+        Ok(Self {
             base_url,
-            collection_name,
+            collection_name: collection_name.to_string(),
             bucket_name,
-        }
+        })
+    }
+
+    fn get_params_from_config(config: Option<Config>) -> Result<(Url, String)> {
+        Ok(match config {
+            Some(config) => {
+                let base_url = config
+                    .server_url
+                    .unwrap_or_else(|| DEFAULT_BASE_URL.to_string());
+                let bucket_name = config
+                    .bucket_name
+                    .unwrap_or_else(|| DEFAULT_BUCKET_NAME.to_string());
+                (Url::parse(&base_url)?, bucket_name)
+            }
+            None => (
+                Url::parse(DEFAULT_BASE_URL)?,
+                DEFAULT_BUCKET_NAME.to_string(),
+            ),
+        })
     }
 
     fn make_request(&self, request: Request) -> Result<Response> {
@@ -38,7 +61,7 @@ impl Client {
         if resp.is_success() || resp.status == status_codes::NOT_MODIFIED {
             Ok(resp)
         } else {
-            anyhow::bail!("Error in request: {}", resp.text())
+            Err(Error::ResponseError(resp.text().to_string()))
         }
     }
 }
@@ -55,8 +78,23 @@ impl SettingsClient for Client {
         );
         let url = self.base_url.join(&path)?;
         let req = Request::get(url);
-        let resp = self.make_request(req)?.json::<Vec<Experiment>>()?;
-        Ok(resp)
+        // We first encode the response into a `serde_json::Value`
+        // to allow us to deserialize each experiment individually,
+        // omitting any malformed experiments
+        let resp = self.make_request(req)?.json::<serde_json::Value>()?;
+        let data = resp.get("data").ok_or(Error::InvalidExperimentResponse)?;
+        let mut res = Vec::new();
+        for exp in data.as_array().ok_or(Error::InvalidExperimentResponse)? {
+            match serde_json::from_value::<Experiment>(exp.clone()) {
+                Ok(exp) => res.push(exp),
+                Err(e) => log::warn!(
+                    "Malformed experiment found! Experiment {},  Error: {}",
+                    exp.get("id").unwrap_or(&serde_json::json!("ID_NOT_FOUND")),
+                    e
+                ),
+            }
+        }
+        Ok(res)
     }
 }
 
@@ -70,6 +108,7 @@ mod tests {
     fn test_get_experiments_from_schema() {
         viaduct_reqwest::use_reqwest_backend();
         let body = r#"
+        { "data":
         [
             {
                 "id": "ABOUTWELCOME-PULL-FACTOR-REINFORCEMENT-76-RELEASE",
@@ -99,25 +138,59 @@ mod tests {
                         { "slug": "treatment-variation-b", "ratio": 1, "value": {} }
                     ]
                 }
+            },
+            {
+                "hello": "bye"
+            },
+            {
+                "id": "ABOUTWELCOME-PULL-FACTOR-REINFORCEMENT-76-RELEASE",
+                "enabled": true,
+                "filter_expression": "(env.version >= '76.' && env.version < '77.' && env.channel == 'release' && !(env.telemetry.main.environment.profile.creationDate < ('2020-05-13'|date / 1000 / 60 / 60 / 24))) || (locale == 'en-US' && [userId, \"aboutwelcome-pull-factor-reinforcement-76-release\"]|bucketSample(0, 2000, 10000) && (!('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue) || 'bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77' in activeExperiments))",
+                "arguments": {
+                    "slug": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
+                    "userFacingName": "About:Welcome Pull Factor Reinforcement",
+                    "userFacingDescription": "4 branch experiment different variants of about:welcome with a goal of testing new experiment framework and get insights on whether reinforcing pull-factors improves retention. Test deployment of multiple branches using new experiment framework",
+                    "isEnrollmentPaused": true,
+                    "active": true,
+                    "bucketConfig": {
+                        "randomizationUnit": "normandy_id",
+                        "namespace": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
+                        "start": 0,
+                        "count": 2000,
+                        "total": 10000
+                    },
+                    "startDate": "2020-06-17T23:20:47.230Z",
+                    "endDate": null,
+                    "proposedDuration": 28,
+                    "proposedEnrollment": 7,
+                    "referenceBranch": "control",
+                    "features": [],
+                    "branches": [
+                        { "slug": "control", "ratio": 1, "value": {}, "group": ["cfr"] },
+                        { "slug": "treatment-variation-b", "ratio": 1, "value": {} }
+                    ]
+                }
             }
-        ]
+
+        ]}
           "#;
         let m = mock(
             "GET",
-            "/buckets/main/collections/messaging-collection/records",
+            "/buckets/main/collections/messaging-experiments/records",
         )
         .with_body(body)
         .with_status(200)
         .with_header("content-type", "application/json")
         .create();
-        let http_client = Client::new(
-            Url::parse(&mockito::server_url()).unwrap(),
-            "messaging-collection".to_string(),
-            "main".to_string(),
-        );
+        let config = Config {
+            server_url: Some(mockito::server_url().to_string()),
+            bucket_name: None,
+            uuid: None,
+        };
+        let http_client = Client::new("messaging-experiments", Some(config)).unwrap();
         let resp = http_client.get_experiments().unwrap();
         m.expect(1).assert();
-        assert_eq!(resp.len(), 1);
+        assert_eq!(resp.len(), 2);
         let exp = &resp[0];
         assert_eq!(exp.clone(), Experiment {
             id: "ABOUTWELCOME-PULL-FACTOR-REINFORCEMENT-76-RELEASE".to_string(),
@@ -138,13 +211,13 @@ mod tests {
                     },
                     start_date: serde_json::from_str("\"2020-06-17T23:20:47.230Z\"").unwrap(),
                     end_date: None,
-                    proposed_duration: 28,
+                    proposed_duration: Some(28),
                     proposed_enrollment: 7,
                     reference_branch: Some("control".to_string()),
                     features: vec![],
                     branches: vec![
-                        Branch { slug: "control".to_string(), ratio: 1, value: BranchValue {}, group: Some(vec![Group::Cfr]) },
-                        Branch { slug: "treatment-variation-b".to_string(), ratio: 1, value: BranchValue {}, group: None }
+                        Branch { slug: "control".to_string(), ratio: 1, value: Some(BranchValue {}), group: Some(vec![Group::Cfr]) },
+                        Branch { slug: "treatment-variation-b".to_string(), ratio: 1, value: Some(BranchValue {}), group: None }
                     ]
                 },
             targeting: None,

--- a/experiments/src/nimbus.idl
+++ b/experiments/src/nimbus.idl
@@ -23,7 +23,6 @@ dictionary EnrolledExperiment {
 dictionary ExperimentConfig {
     string? server_url;
     string? uuid;
-    string? collection_name;
     string? bucket_name;
 };
 
@@ -31,12 +30,13 @@ dictionary ExperimentConfig {
 enum Error {
    "InvalidPersistedData", "RkvError", "IOError",
    "JSONError", "EvaluationError", "InvalidExpression", "InvalidFraction",
-    "TryFromSliceError", "EmptyRatiosError", "OutOfBoundsError"
+    "TryFromSliceError", "EmptyRatiosError", "OutOfBoundsError","UrlParsingError",
+    "RequestError", "ResponseError", "InvalidExperimentResponse"
 };
 
 interface Experiments {
     [Throws=Error]
-    constructor(AppContext app_ctx, string dbpath, ExperimentConfig? config);
+    constructor(string collection_name, AppContext app_ctx, string dbpath, ExperimentConfig? config);
 
 
     string? get_experiment_branch(string experiment_slug);


### PR DESCRIPTION
This PR allows us to query experiments from [stage](https://settings.stage.mozaws.net/v1/buckets/main/collections/messaging-experiments/records) that abide by the nimbus schema, and omitting experiments that do not abide by the schema (with a minor detail, the `proposedDuration` is missing from ***all*** experiments in stage, so I made it optional (although the schema said it's required) and added a TODO there.