### PR TITLE
Bug 1656502, 1631658 - Add FeatureConfig and deprecate use of filter_expression

### DIFF
--- a/experiments/src/evaluator.rs
+++ b/experiments/src/evaluator.rs
@@ -128,7 +128,7 @@ pub(crate) fn targeting(expression_statement: &str, ctx: AppContext) -> Result<b
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{BucketConfig, ExperimentArguments, RandomizationUnit};
+    use crate::{BucketConfig, ExperimentArguments, FeatureConfig, Group, RandomizationUnit};
     #[test]
     fn test_targeting() {
         // Here's our valid jexl statement
@@ -230,15 +230,21 @@ mod tests {
         let branches = vec![
             Branch {
                 slug: "control".to_string(),
-                group: None,
                 ratio: 1,
-                value: None,
+                feature: FeatureConfig {
+                    feature_id: Group::Cfr,
+                    enabled: true,
+                    value: None,
+                },
             },
             Branch {
                 slug: "blue".to_string(),
-                group: None,
                 ratio: 1,
-                value: None,
+                feature: FeatureConfig {
+                    feature_id: Group::Cfr,
+                    enabled: true,
+                    value: None,
+                },
             },
         ];
         // 299eed1e-be6d-457d-9e53-da7b1a03f10d maps to the second index
@@ -255,7 +261,6 @@ mod tests {
     fn test_filter_enrolled() {
         let experiment1 = Experiment {
             id: "ID_1".to_string(),
-            filter_expression: "".to_string(),
             targeting: Default::default(),
             enabled: true,
             arguments: ExperimentArguments {
@@ -272,8 +277,8 @@ mod tests {
                     total: 10000,
                 },
                 features: Default::default(),
-                branches: vec![Branch {slug: "control".to_string(), group: None, ratio: 1, value: None},
-                Branch {slug: "blue".to_string(), group: None, ratio: 1, value: None}],
+                branches: vec![Branch {slug: "control".to_string(), ratio: 1, feature: FeatureConfig { feature_id: Group::Cfr, enabled: true, value: None }},
+                Branch {slug: "blue".to_string(), ratio: 1, feature: FeatureConfig { feature_id: Group::Cfr, enabled: true, value: None }}],
                 start_date: serde_json::from_str("\"2020-06-17T23:20:47.230Z\"").unwrap(),
                 end_date: Default::default(),
                 proposed_duration: Default::default(),

--- a/experiments/src/http_client.rs
+++ b/experiments/src/http_client.rs
@@ -101,7 +101,9 @@ impl SettingsClient for Client {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Branch, BranchValue, BucketConfig, ExperimentArguments, Group, RandomizationUnit};
+    use crate::{
+        Branch, BucketConfig, ExperimentArguments, FeatureConfig, Group, RandomizationUnit,
+    };
     use mockito::mock;
 
     #[test]
@@ -113,7 +115,7 @@ mod tests {
             {
                 "id": "ABOUTWELCOME-PULL-FACTOR-REINFORCEMENT-76-RELEASE",
                 "enabled": true,
-                "filter_expression": "(env.version >= '76.' && env.version < '77.' && env.channel == 'release' && !(env.telemetry.main.environment.profile.creationDate < ('2020-05-13'|date / 1000 / 60 / 60 / 24))) || (locale == 'en-US' && [userId, \"aboutwelcome-pull-factor-reinforcement-76-release\"]|bucketSample(0, 2000, 10000) && (!('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue) || 'bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77' in activeExperiments))",
+                "targeting": "(firefoxVersion >= 76 && firefoxVersion < 77 && channel == 'release') || (locale == 'en-US' && [userId, \"aboutwelcome-pull-factor-reinforcement-76-release\"]|bucketSample(0, 2000, 10000) && (!('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue) || 'bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77' in activeExperiments))",
                 "arguments": {
                     "slug": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
                     "userFacingName": "About:Welcome Pull Factor Reinforcement",
@@ -134,8 +136,8 @@ mod tests {
                     "referenceBranch": "control",
                     "features": [],
                     "branches": [
-                        { "slug": "control", "ratio": 1, "value": {}, "group": ["cfr"] },
-                        { "slug": "treatment-variation-b", "ratio": 1, "value": {} }
+                        { "slug": "control", "ratio": 1, "feature": { "featureId": "cfr", "enabled": true, "value": null } },
+                        { "slug": "treatment-variation-b", "ratio": 1, "feature": { "featureId": "cfr", "enabled": true, "value": null } }
                     ]
                 }
             },
@@ -145,7 +147,7 @@ mod tests {
             {
                 "id": "ABOUTWELCOME-PULL-FACTOR-REINFORCEMENT-76-RELEASE",
                 "enabled": true,
-                "filter_expression": "(env.version >= '76.' && env.version < '77.' && env.channel == 'release' && !(env.telemetry.main.environment.profile.creationDate < ('2020-05-13'|date / 1000 / 60 / 60 / 24))) || (locale == 'en-US' && [userId, \"aboutwelcome-pull-factor-reinforcement-76-release\"]|bucketSample(0, 2000, 10000) && (!('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue) || 'bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77' in activeExperiments))",
+                "targeting": "(firefoxVersion >= 76 && firefoxVersion < 77 && channel == 'release') || (locale == 'en-US' && [userId, \"aboutwelcome-pull-factor-reinforcement-76-release\"]|bucketSample(0, 2000, 10000) && (!('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue) || 'bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77' in activeExperiments))",
                 "arguments": {
                     "slug": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
                     "userFacingName": "About:Welcome Pull Factor Reinforcement",
@@ -166,8 +168,8 @@ mod tests {
                     "referenceBranch": "control",
                     "features": [],
                     "branches": [
-                        { "slug": "control", "ratio": 1, "value": {}, "group": ["cfr"] },
-                        { "slug": "treatment-variation-b", "ratio": 1, "value": {} }
+                        { "slug": "control", "ratio": 1, "feature": { "featureId": "cfr", "enabled": true, "value": null } },
+                        { "slug": "treatment-variation-b", "ratio": 1, "feature": { "featureId": "cfr", "enabled": true, "value": null } }
                     ]
                 }
             }
@@ -195,7 +197,7 @@ mod tests {
         assert_eq!(exp.clone(), Experiment {
             id: "ABOUTWELCOME-PULL-FACTOR-REINFORCEMENT-76-RELEASE".to_string(),
             enabled: true,
-            filter_expression: "(env.version >= '76.' && env.version < '77.' && env.channel == 'release' && !(env.telemetry.main.environment.profile.creationDate < ('2020-05-13'|date / 1000 / 60 / 60 / 24))) || (locale == 'en-US' && [userId, \"aboutwelcome-pull-factor-reinforcement-76-release\"]|bucketSample(0, 2000, 10000) && (!('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue) || 'bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77' in activeExperiments))".to_string(),
+            targeting: Some("(firefoxVersion >= 76 && firefoxVersion < 77 && channel == 'release') || (locale == 'en-US' && [userId, \"aboutwelcome-pull-factor-reinforcement-76-release\"]|bucketSample(0, 2000, 10000) && (!('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue) || 'bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77' in activeExperiments))".to_string()),
             arguments: ExperimentArguments {
                     slug: "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77".to_string(),
                     user_facing_name: "About:Welcome Pull Factor Reinforcement".to_string(),
@@ -216,11 +218,10 @@ mod tests {
                     reference_branch: Some("control".to_string()),
                     features: vec![],
                     branches: vec![
-                        Branch { slug: "control".to_string(), ratio: 1, value: Some(BranchValue {}), group: Some(vec![Group::Cfr]) },
-                        Branch { slug: "treatment-variation-b".to_string(), ratio: 1, value: Some(BranchValue {}), group: None }
+                        Branch { slug: "control".to_string(), ratio: 1, feature: FeatureConfig { feature_id: Group::Cfr, enabled: true, value: None } },
+                        Branch { slug: "treatment-variation-b".to_string(), ratio: 1, feature: FeatureConfig { feature_id: Group::Cfr, enabled: true, value: None } }
                     ]
                 },
-            targeting: None,
         })
     }
 }

--- a/experiments/src/lib.rs
+++ b/experiments/src/lib.rs
@@ -94,7 +94,6 @@ impl Experiments {
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct Experiment {
     pub id: String,
-    pub filter_expression: String,
     pub targeting: Option<String>,
     pub enabled: bool,
     pub arguments: ExperimentArguments,
@@ -120,11 +119,18 @@ pub struct ExperimentArguments {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FeatureConfig {
+    pub feature_id: Group,
+    pub enabled: bool,
+    pub value: Option<BranchValue>,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct Branch {
     pub slug: String,
     pub ratio: u32,
-    pub group: Option<Vec<Group>>,
-    pub value: Option<BranchValue>,
+    pub feature: FeatureConfig,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]


### PR DESCRIPTION
Sync schema changes between [mozilla-central](https://searchfox.org/mozilla-central/rev/84922363f4014eae684aabc4f1d06380066494c5/toolkit/components/messaging-system/experiments/@types/ExperimentManager.d.ts) and nimbus-shared (https://github.com/mozilla/nimbus-shared/pull/119 and https://github.com/mozilla/nimbus-shared/pull/118/)