### PR TITLE
[SYNC-1751] Fix packaging of nimbus to include native libs for unittesting.

### DIFF
--- a/android/.buildconfig.yaml
+++ b/android/.buildconfig.yaml
@@ -2,7 +2,7 @@ libraryVersion: 0.1.0
 groupId: uniffi
 artifactId: nimbus
 description: A uniffi generated android bindings for the Nimbus SDK
-libUrl: https://github.com/mozilla/glean
-libVcsUrl: https://github.com/mozilla/glean.git
+libUrl: https://github.com/mozilla/nimbus-sdk
+libVcsUrl: https://github.com/mozilla/nimbus-sdk.git
 libLicense: MPL-2.0
 libLicenseUrl: https://www.mozilla.org/en-US/MPL/2.0/

--- a/android/.buildconfig.yaml
+++ b/android/.buildconfig.yaml
@@ -2,3 +2,7 @@ libraryVersion: 0.1.0
 groupId: uniffi
 artifactId: nimbus
 description: A uniffi generated android bindings for the Nimbus SDK
+libUrl: https://github.com/mozilla/glean
+libVcsUrl: https://github.com/mozilla/glean.git
+libLicense: MPL-2.0
+libLicenseUrl: https://www.mozilla.org/en-US/MPL/2.0/

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -194,7 +194,12 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        tasks["merge${productFlavor}${buildType}JniLibFolders"].dependsOn(tasks["cargoBuild"])
+        // tasks["merge${productFlavor}${buildType}JniLibFolders"].dependsOn(tasks["cargoBuild"])
+
+        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+
+        // For unit tests.
+        tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])
     }
 }
 
@@ -213,7 +218,7 @@ android.libraryVariants.all { variant ->
 }
 
 allprojects {
-    group = "uniffi"
+    group = "uniffi.nimbus"
     apply plugin: 'digital.wup.android-maven-publish'
 
     // This allows to invoke Gradle like `./gradlew publishToRootProjectBuildDir` (equivalent to

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -118,6 +118,10 @@ android {
             includeAndroidResources = true
         }
     }
+
+    lintOptions {
+        abortOnError false
+    }
 }
 
 allprojects {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -202,9 +202,7 @@ afterEvaluate {
             productFlavor += "${it.name.capitalize()}"
         }
         def buildType = "${variant.buildType.name.capitalize()}"
-        // tasks["merge${productFlavor}${buildType}JniLibFolders"].dependsOn(tasks["cargoBuild"])
-
-        tasks["generate${productFlavor}${buildType}Assets"].dependsOn(tasks["cargoBuild"])
+        tasks["merge${productFlavor}${buildType}JniLibFolders"].dependsOn(tasks["cargoBuild"])
 
         // For unit tests.
         tasks["process${productFlavor}${buildType}UnitTestJavaRes"].dependsOn(tasks["cargoBuild"])

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,7 +49,27 @@ buildscript {
     }
 }
 
+configurations {
+    // There's an interaction between Gradle's resolution of dependencies with different types
+    // (@jar, @aar) for `implementation` and `testImplementation` and with Android Studio's built-in
+    // JUnit test runner.  The runtime classpath in the built-in JUnit test runner gets the
+    // dependency from the `implementation`, which is type @aar, and therefore the JNA dependency
+    // doesn't provide the JNI dispatch libraries in the correct Java resource directories.  I think
+    // what's happening is that @aar type in `implementation` resolves to the @jar type in
+    // `testImplementation`, and that it wins the dependency resolution battle.
+    //
+    // A workaround is to add a new configuration which depends on the @jar type and to reference
+    // the underlying JAR file directly in `testImplementation`.  This JAR file doesn't resolve to
+    // the @aar type in `implementation`.  This works when invoked via `gradle`, but also sets the
+    // correct runtime classpath when invoked with Android Studio's built-in JUnit test runner.
+    // Success!
+    jnaForTest
+}
 
+dependencies {
+    jnaForTest "net.java.dev.jna:jna:$jna_version@jar"
+    implementation "net.java.dev.jna:jna:$jna_version@aar"
+}
 
 android {
     compileSdkVersion 29
@@ -71,6 +91,33 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    // This is required to support new AndroidX support libraries.
+    // See mozilla-mobile/android-components#842
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
+
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+        kotlinOptions {
+            jvmTarget = "1.8"
+        }
+    }
+
+    testOptions {
+        unitTests.all {
+            testLogging {
+                showStandardStreams = true
+            }
+
+            maxHeapSize = "1024m"
+        }
+
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 allprojects {
@@ -90,17 +137,29 @@ allprojects {
     }
 }
 
-ext {
-    rustTargets = [
+// Avoid Gradle namespace collision.  This is here, rather than in `buildscript
+// { ... }`, to avoid issues with importing.
+import com.sun.jna.Platform as DefaultPlatform
+
+ext.rustTargets = [
         'arm',
         'arm64',
         'x86_64',
         'x86',
-    ]
+]
 
+// Generate libs for our current platform so we can run unit tests.
+switch (DefaultPlatform.RESOURCE_PREFIX) {
+    case 'darwin':
+        ext.rustTargets += 'darwin'
+        break
+    case 'linux-x86-64':
+        ext.rustTargets += 'linux-x86-64'
+        break
+    case 'win32-x86-64':
+        ext.rustTargets += 'win32-x86-64-msvc'
+        break
 }
-
-// TODO: Add current platform to rustTargets to allow for unit testing
 
 cargo {
     // The directory of the Cargo.toml to build.
@@ -126,7 +185,6 @@ cargo {
 
     extraCargoBuildArguments = []
 }
-
 
 afterEvaluate {
     // The `cargoBuild` task isn't available until after evaluation.
@@ -155,7 +213,7 @@ android.libraryVariants.all { variant ->
 }
 
 allprojects {
-    group = "uniffi.nimbus"
+    group = "uniffi"
     apply plugin: 'digital.wup.android-maven-publish'
 
     // This allows to invoke Gradle like `./gradlew publishToRootProjectBuildDir` (equivalent to
@@ -176,5 +234,5 @@ allprojects {
 
 apply from: "./publish.gradle"
 
-ext.configurePublish()
+ext.configurePublish(configurations.jnaForTest)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -122,6 +122,10 @@ android {
     lintOptions {
         abortOnError false
     }
+
+    sourceSets {
+        test.jniLibs.srcDirs += "$buildDir/rustJniLibs/desktop"
+    }
 }
 
 allprojects {
@@ -173,7 +177,7 @@ cargo {
     apiLevel = 29
 
     // Where Cargo writes its outputs.
-    targetDirectory = '../target'
+    targetDirectory = '../experiments/target'
 
     // This is the name of the library that the kotlin code
     // *must* use to import the native code

--- a/android/publish.gradle
+++ b/android/publish.gradle
@@ -1,5 +1,10 @@
 apply from: './settings.gradle'
 
+// The note to be added at the end of the description for 'forUnitTests'
+// artifacts.
+def forUnitTestDescriptionSuffix =
+        "This artifact is to be used for running unit tests on developer's systems."
+
 // We configure what we publish when
 // running `./gradlew publish...`
 ext.configurePublish = { jnaForTestConfiguration = null ->
@@ -9,6 +14,38 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
     def theArtifactId = ext.artifactId
     def theDescription = ext.description
     def theVersion = ext.version
+
+    task extractJnaResources(type: Sync) {
+        dependsOn jnaForTestConfiguration
+
+        from {
+            // Defer the resolution of the configuration.  This helps to
+            // avoid a nasty issue with the Android-Gradle plugin 3.2.1,
+            // like `Cannot change attributes of configuration
+            // ':PROJECT:kapt' after it has been resolved`.
+            zipTree(jnaForTestConfiguration.singleFile)
+        }
+
+        into "${buildDir}/jnaResources/"
+
+        eachFile { FileCopyDetails fcp ->
+            // The intention is to just keep the various `*jnidispatch.*` files.
+            if (fcp.relativePath.pathString.startsWith("META-INFO") || fcp.relativePath.pathString.endsWith(".class")) {
+                fcp.exclude()
+            }
+        }
+
+        includeEmptyDirs false
+    }
+
+    def forUnitTestsJarTask = task forUnitTestsJar(type: Jar) {
+        from extractJnaResources
+        from "$buildDir/rustJniLibs/desktop"
+    }
+
+    project.afterEvaluate {
+        forUnitTestsJarTask.dependsOn(tasks["cargoBuild"])
+    }
 
     task sourcesJar(type: Jar) {
         from android.sourceSets.main.java.srcDirs
@@ -34,6 +71,12 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
                     version = theVersion + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
                     packaging = "aar"
 
+                    licenses {
+                        license {
+                            name = libLicense
+                            url = libLicenseUrl
+                        }
+                    }
 
                     developers {
                         developer {
@@ -41,7 +84,60 @@ ext.configurePublish = { jnaForTestConfiguration = null ->
                         }
                     }
 
+                    scm {
+                        connection = libVcsUrl
+                        developerConnection = libVcsUrl
+                        url = libUrl
+                    }
                 }
+            }
+
+            forUnitTestsJar(MavenPublication) {
+                artifact tasks['forUnitTestsJar']
+                pom {
+                    groupId = theGroupId
+                    artifactId = "${theArtifactId}-forUnitTests"
+                    description = theDescription + " " + forUnitTestDescriptionSuffix
+                    version = theVersion + (rootProject.hasProperty('local') ? '-' + rootProject.property('local') : '')
+                    packaging = "jar"
+
+                    licenses {
+                        license {
+                            name = libLicense
+                            url = libLicenseUrl
+                        }
+                    }
+
+                    developers {
+                        developer {
+                            name = 'Mozilla Nimbus SDK'
+                        }
+                    }
+
+                    scm {
+                        connection = libVcsUrl
+                        developerConnection = libVcsUrl
+                        url = libUrl
+                    }
+                }
+
+                pom.withXml {
+                    // The 'forUnitTest' JAR, used to run unit tests on the host system,
+                    // needs to declare any dependency it requires (e.g. JNA).
+                    def dependenciesNode = asNode().appendNode("dependencies")
+                    configurations["jnaForTest"].allDependencies.forEach {
+                        if (it.group != null) {
+                            def dependencyNode = dependenciesNode.appendNode("dependency")
+                            dependencyNode.appendNode("groupId", it.group)
+                            dependencyNode.appendNode("artifactId", it.name)
+                            dependencyNode.appendNode("version", it.version)
+                        }
+                    }
+                }
+
+                // This is never the publication we want to use when publishing a
+                // parent project with us as a child `project()` dependency.
+                alias = true
             }
         }
     }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -20,3 +20,7 @@ ext.description = buildconfig.description
 ext.version = buildconfig.libraryVersion
 ext.groupId = buildconfig.groupId
 ext.artifactId = buildconfig.artifactId
+ext.libUrl = buildconfig.libUrl
+ext.libVcsUrl = buildconfig.libVcsUrl
+ext.libLicense = buildconfig.libLicense
+ext.libLicenseUrl = buildconfig.libLicenseUrl

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 buildscript {
     dependencies {
-        classpath 'org.yaml:snakeyaml:1.23'
+        classpath 'org.yaml:snakeyaml:1.26'
     }
     repositories {
         jcenter()

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="uniffi.nimbus">
-
-    /
 </manifest>

--- a/experiments/Cargo.toml
+++ b/experiments/Cargo.toml
@@ -10,8 +10,8 @@ license = "MPL-2.0"
 keywords = ["experiment"]
 
 [lib]
-name = "experiments"
-crate-type = ["lib"]
+name = "nimbus"
+crate-type = ["lib", "cdylib"]
 
 [dependencies]
 anyhow = "1"

--- a/experiments/examples/experiment.rs
+++ b/experiments/examples/experiment.rs
@@ -4,7 +4,7 @@
 
 use clap::{App, Arg, SubCommand};
 use env_logger::Env;
-use experiments::{AppContext, ExperimentConfig, Experiments};
+use nimbus::{AppContext, ExperimentConfig, Experiments};
 use std::io::prelude::*;
 
 const DEFAULT_BASE_URL: &str = "https://settings.stage.mozaws.net"; // TODO: Replace this with prod
@@ -121,7 +121,7 @@ fn main() {
             let mut uuid = uuid::Uuid::new_v4();
             while num_of_experiments_enrolled != num {
                 uuid = uuid::Uuid::new_v4();
-                num_of_experiments_enrolled = experiments::filter_enrolled(&uuid, &all_experiments)
+                num_of_experiments_enrolled = nimbus::filter_enrolled(&uuid, &all_experiments)
                     .unwrap()
                     .len()
             }


### PR DESCRIPTION
This is a WIP towards getting unit tests to run (in consuming code like the [Nimbus Android-Component](https://github.com/mozilla-mobile/android-components/pull/8261)) and include the local system libs rather than just the android libs.