### PR TITLE
Rollback uniffi version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - run:
           name: Install uniffi
-          command: git clone https://github.com/mozilla/uniffi-rs.git; cargo install --path uniffi-rs/uniffi_bindgen
+          command: git clone https://github.com/mozilla/uniffi-rs.git; cd uniffi-rs && git checkout f025ceef31270918329f3ced772f7d68caaf255e && cd ..; cargo install --path uniffi-rs/uniffi_bindgen
       - run:
           name: Calculate dependencies
           command: cd experiments && cargo generate-lockfile


### PR DESCRIPTION
RustBuffer changes caused a fail in https://app.circleci.com/pipelines/github/mozilla/nimbus-sdk/77/workflows/3c19ee42-9ba9-4ee0-893d-3d39a027d122/jobs/84