### PR TITLE
Install uniffi from crates.io in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           command: rustc --version; cargo --version; rustup --version
       - run:
           name: Install uniffi
-          command: git clone https://github.com/mozilla/uniffi-rs.git; cd uniffi-rs && git checkout f025ceef31270918329f3ced772f7d68caaf255e && cd ..; cargo install --path uniffi-rs/uniffi_bindgen
+          command: cargo install --version 0.1.0 uniffi_bindgen
       - run:
           name: Calculate dependencies
           command: cd experiments && cargo generate-lockfile


### PR DESCRIPTION
It's important that the version installed here matches the version used in the `Cargo.toml` of the experiments crate.

I think this should fix the issue from https://github.com/mozilla/nimbus-sdk/pull/22, closing https://github.com/mozilla/application-services/issues/3583.