### PR TITLE
Replace RandomizationUnit with a plain Uuid.

### DIFF
--- a/experiments/src/evaluator.rs
+++ b/experiments/src/evaluator.rs
@@ -128,7 +128,7 @@ pub(crate) fn targeting(expression_statement: &str, ctx: AppContext) -> Result<b
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{BucketConfig, ExperimentArguments, FeatureConfig, Group, RandomizationUnit};
+    use crate::{uuid::generate_uuid, BucketConfig, ExperimentArguments, FeatureConfig, Group};
     #[test]
     fn test_targeting() {
         // Here's our valid jexl statement
@@ -270,7 +270,7 @@ mod tests {
                 active: true,
                 is_enrollment_paused: false,
                 bucket_config: BucketConfig {
-                    randomization_unit: RandomizationUnit::NormandyId,
+                    randomization_unit: generate_uuid(None),
                     namespace: "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77".to_string(),
                     start: 0,
                     count: 2000,
@@ -288,7 +288,7 @@ mod tests {
         };
         let mut experiment2 = experiment1.clone();
         experiment2.arguments.bucket_config = BucketConfig {
-            randomization_unit: RandomizationUnit::NormandyId,
+            randomization_unit: generate_uuid(None),
             namespace:
                 "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77"
                     .to_string(),

--- a/experiments/src/http_client.rs
+++ b/experiments/src/http_client.rs
@@ -102,14 +102,15 @@ impl SettingsClient for Client {
 mod tests {
     use super::*;
     use crate::{
-        Branch, BucketConfig, ExperimentArguments, FeatureConfig, Group, RandomizationUnit,
+        uuid::generate_uuid, Branch, BucketConfig, ExperimentArguments, FeatureConfig, Group,
     };
     use mockito::mock;
 
     #[test]
     fn test_get_experiments_from_schema() {
         viaduct_reqwest::use_reqwest_backend();
-        let body = r#"
+        let uid = generate_uuid(None);
+        let body = serde_json::json!(
         { "data":
         [
             {
@@ -123,7 +124,7 @@ mod tests {
                     "isEnrollmentPaused": true,
                     "active": true,
                     "bucketConfig": {
-                        "randomizationUnit": "normandy_id",
+                        "randomizationUnit": uid,
                         "namespace": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
                         "start": 0,
                         "count": 2000,
@@ -155,7 +156,7 @@ mod tests {
                     "isEnrollmentPaused": true,
                     "active": true,
                     "bucketConfig": {
-                        "randomizationUnit": "normandy_id",
+                        "randomizationUnit": uid,
                         "namespace": "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77",
                         "start": 0,
                         "count": 2000,
@@ -174,13 +175,12 @@ mod tests {
                 }
             }
 
-        ]}
-          "#;
+        ]});
         let m = mock(
             "GET",
             "/buckets/main/collections/messaging-experiments/records",
         )
-        .with_body(body)
+        .with_body(body.to_string())
         .with_status(200)
         .with_header("content-type", "application/json")
         .create();
@@ -205,7 +205,7 @@ mod tests {
                     is_enrollment_paused: true,
                     active: true,
                     bucket_config: BucketConfig {
-                        randomization_unit: RandomizationUnit::NormandyId,
+                        randomization_unit: uid,
                         namespace: "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77".to_string(),
                         start: 0,
                         count: 2000,

--- a/experiments/src/lib.rs
+++ b/experiments/src/lib.rs
@@ -151,21 +151,12 @@ fn default_buckets() -> u32 {
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct BucketConfig {
-    pub randomization_unit: RandomizationUnit,
+    pub randomization_unit: Uuid,
     pub namespace: String,
     pub start: u32,
     pub count: u32,
     #[serde(default = "default_buckets")]
     pub total: u32,
-}
-
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum RandomizationUnit {
-    ClientId,
-    NormandyId,
-    #[serde(rename = "userId")]
-    UserId,
 }
 
 include!(concat!(env!("OUT_DIR"), "/nimbus.uniffi.rs"));


### PR DESCRIPTION
I think there was some confusion around the discussion about how to choose
the Uuid used as the RandomizationUnit. We might need an enum later if we
do need to choose between different Uuids based on the experiment, but we
can add that once the requirements are clearer.