### PR TITLE
Closes [EXP-384] Implement get_experiment_branch

### DIFF
--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -63,13 +63,10 @@ impl NimbusClient {
     }
 
     pub fn get_experiment_branch(&self, _slug: String) -> Option<String> {
-        let enrolled_experiment = self.enrolled_experiments
+        self.enrolled_experiments
             .iter()
-            .find(|e| e.slug == _slug);
-        match enrolled_experiment {
-            Some(e) => { Some(e.branch_slug.clone()) }
-            None => { None }
-        }
+            .find(|e| e.slug == _slug)
+            .map(|e| e.branch_slug.clone())
     }
 
     pub fn get_active_experiments(&self) -> Vec<EnrolledExperiment> {

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -63,7 +63,13 @@ impl NimbusClient {
     }
 
     pub fn get_experiment_branch(&self, _slug: String) -> Option<String> {
-        unimplemented!();
+        let enrolled_experiment = self.enrolled_experiments
+            .iter()
+            .find(|e| e.slug == _slug);
+        match enrolled_experiment {
+            Some(e) => { Some(e.branch_slug.clone()) }
+            None => { None }
+        }
     }
 
     pub fn get_active_experiments(&self) -> Vec<EnrolledExperiment> {


### PR DESCRIPTION
This implements the functionality for get_experiment_branch.  Upon implementing this, I realized that this function was not extremely useful aside from a convenience function since we already return the branch slug as a property of the collection of EnrolledExperiments.