### PR TITLE
IDs refactor

### DIFF
--- a/nimbus/examples/experiment.rs
+++ b/nimbus/examples/experiment.rs
@@ -4,7 +4,7 @@
 
 use clap::{App, Arg, SubCommand};
 use env_logger::Env;
-use nimbus::{AppContext, ExperimentConfig, NimbusClient};
+use nimbus::{AppContext, Config, NimbusClient};
 use std::io::prelude::*;
 
 const DEFAULT_BASE_URL: &str = "https://settings.stage.mozaws.net"; // TODO: Replace this with prod
@@ -75,7 +75,7 @@ fn main() {
     log::info!("Collection name is {}", collection_name);
 
     // initiate the optional config
-    let config = ExperimentConfig {
+    let config = Config {
         server_url: Some(server_url.to_string()),
         bucket_name: Some(bucket_name.to_string()),
     };

--- a/nimbus/examples/experiment.rs
+++ b/nimbus/examples/experiment.rs
@@ -4,7 +4,7 @@
 
 use clap::{App, Arg, SubCommand};
 use env_logger::Env;
-use nimbus::{AppContext, Config, NimbusClient};
+use nimbus::{AppContext, AvailableRandomizationUnits, Config, NimbusClient};
 use std::io::prelude::*;
 
 const DEFAULT_BASE_URL: &str = "https://settings.stage.mozaws.net"; // TODO: Replace this with prod
@@ -80,9 +80,17 @@ fn main() {
         bucket_name: Some(bucket_name.to_string()),
     };
 
+    let available_randomization_units = AvailableRandomizationUnits { client_id: None };
+
     // Here we initialize our main `NimbusClient` struct
-    let nimbus_client =
-        NimbusClient::new(collection_name.to_string(), context, "", Some(config)).unwrap();
+    let nimbus_client = NimbusClient::new(
+        collection_name.to_string(),
+        context,
+        "",
+        Some(config),
+        available_randomization_units,
+    )
+    .unwrap();
 
     // We match against the subcommands
     match matches.subcommand() {
@@ -114,11 +122,15 @@ fn main() {
             let all_experiments = nimbus_client.get_all_experiments();
             let mut num_of_experiments_enrolled = 0;
             let mut uuid = uuid::Uuid::new_v4();
+            let available_randomization_units = AvailableRandomizationUnits {
+                client_id: Some("bobo".to_string()),
+            };
             while num_of_experiments_enrolled != num {
                 uuid = uuid::Uuid::new_v4();
-                num_of_experiments_enrolled = nimbus::filter_enrolled(&uuid, &all_experiments)
-                    .unwrap()
-                    .len()
+                num_of_experiments_enrolled =
+                    nimbus::filter_enrolled(&uuid, &available_randomization_units, &all_experiments)
+                        .unwrap()
+                        .len()
             }
             println!("======================================");
             println!("Generated UUID is: {}", uuid);

--- a/nimbus/examples/experiment.rs
+++ b/nimbus/examples/experiment.rs
@@ -4,7 +4,7 @@
 
 use clap::{App, Arg, SubCommand};
 use env_logger::Env;
-use nimbus::{AppContext, AvailableRandomizationUnits, Config, NimbusClient};
+use nimbus::{AppContext, AvailableRandomizationUnits, NimbusClient, RemoteSettingsConfig};
 use std::io::prelude::*;
 
 const DEFAULT_BASE_URL: &str = "https://settings.stage.mozaws.net"; // TODO: Replace this with prod
@@ -75,7 +75,7 @@ fn main() {
     log::info!("Collection name is {}", collection_name);
 
     // initiate the optional config
-    let config = Config {
+    let config = RemoteSettingsConfig {
         server_url: Some(server_url.to_string()),
         bucket_name: Some(bucket_name.to_string()),
     };

--- a/nimbus/examples/experiment.rs
+++ b/nimbus/examples/experiment.rs
@@ -74,15 +74,10 @@ fn main() {
 
     log::info!("Collection name is {}", collection_name);
 
-    // For the uuid, we do not set a default value, instead
-    // a random uuid will be generated if none is provided
-    let uuid = config.get("uuid").map(|u| u.as_str().unwrap().to_string());
-
     // initiate the optional config
     let config = ExperimentConfig {
         server_url: Some(server_url.to_string()),
         bucket_name: Some(bucket_name.to_string()),
-        uuid,
     };
 
     // Here we initialize our main `NimbusClient` struct

--- a/nimbus/src/config.rs
+++ b/nimbus/src/config.rs
@@ -11,11 +11,9 @@
 /// Optional custom configuration
 /// Currently includes the following:
 /// - `server_url`: The url for the settings server that would be used to retrieve experiments
-/// - `uuid`: A custom user uuid that would otherwise be generated or loaded from persisted storage
 /// - `bucket_name`: The name of the bucket containing the collection on the server
 #[derive(Debug, Clone)]
 pub struct Config {
     pub server_url: Option<String>,
-    pub uuid: Option<String>,
     pub bucket_name: Option<String>,
 }

--- a/nimbus/src/config.rs
+++ b/nimbus/src/config.rs
@@ -13,7 +13,7 @@
 /// - `server_url`: The url for the settings server that would be used to retrieve experiments
 /// - `bucket_name`: The name of the bucket containing the collection on the server
 #[derive(Debug, Clone)]
-pub struct Config {
+pub struct RemoteSettingsConfig {
     pub server_url: Option<String>,
     pub bucket_name: Option<String>,
 }

--- a/nimbus/src/evaluator.rs
+++ b/nimbus/src/evaluator.rs
@@ -63,6 +63,8 @@ pub fn filter_enrolled(
         {
             Some(id) => id,
             None => {
+                // XXX: When we link we glean, it would be nice
+                // if we could emit a failure telemetry event here.
                 log::info!(
                     "Could not find a suitable randomization unit for {}. Skipping experiment.",
                     &exp.slug

--- a/nimbus/src/http_client.rs
+++ b/nimbus/src/http_client.rs
@@ -161,7 +161,6 @@ mod tests {
         let config = Config {
             server_url: Some(mockito::server_url()),
             bucket_name: None,
-            uuid: None,
         };
         let http_client = Client::new("messaging-experiments", Some(config)).unwrap();
         let resp = http_client.get_experiments().unwrap();

--- a/nimbus/src/http_client.rs
+++ b/nimbus/src/http_client.rs
@@ -14,7 +14,7 @@
 //! But the simple subset implemented here meets our needs for now.
 
 use super::Experiment;
-use crate::config::Config;
+use crate::config::RemoteSettingsConfig;
 use crate::error::{Error, Result};
 use url::Url;
 use viaduct::{status_codes, Request, Response};
@@ -36,8 +36,11 @@ pub struct Client {
 
 impl Client {
     #[allow(unused)]
-    pub fn new(collection_name: &str, config: Option<Config>) -> Result<Self> {
-        let (base_url, bucket_name) = Self::get_params_from_config(config)?;
+    pub fn new(
+        collection_name: &str,
+        remote_settings_config: Option<RemoteSettingsConfig>,
+    ) -> Result<Self> {
+        let (base_url, bucket_name) = Self::get_params_from_config(remote_settings_config)?;
         Ok(Self {
             base_url,
             collection_name: collection_name.to_string(),
@@ -45,7 +48,7 @@ impl Client {
         })
     }
 
-    fn get_params_from_config(config: Option<Config>) -> Result<(Url, String)> {
+    fn get_params_from_config(config: Option<RemoteSettingsConfig>) -> Result<(Url, String)> {
         Ok(match config {
             Some(config) => {
                 let base_url = config
@@ -158,7 +161,7 @@ mod tests {
         .with_status(200)
         .with_header("content-type", "application/json")
         .create();
-        let config = Config {
+        let config = RemoteSettingsConfig {
             server_url: Some(mockito::server_url()),
             bucket_name: None,
         };

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -168,8 +168,7 @@ pub struct BucketConfig {
 #[serde(rename_all = "snake_case")]
 pub enum RandomizationUnit {
     NimbusId,
-    #[serde(rename = "userId")]
-    UserId,
+    ClientId,
 }
 
 impl Default for RandomizationUnit {

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -14,7 +14,7 @@ mod sampling;
 pub use evaluator::filter_enrolled;
 
 use ::uuid::Uuid;
-pub use config::Config;
+pub use config::RemoteSettingsConfig;
 use http_client::{Client, SettingsClient};
 pub use matcher::AppContext;
 use persistence::Database;
@@ -48,7 +48,7 @@ impl NimbusClient {
         collection_name: String,
         app_context: AppContext,
         db_path: P,
-        config: Option<Config>,
+        config: Option<RemoteSettingsConfig>,
         available_randomization_units: AvailableRandomizationUnits,
     ) -> Result<Self> {
         let client = Client::new(&collection_name, config.clone())?;

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -32,7 +32,7 @@ pub struct NimbusClient {
     enrolled_experiments: Vec<EnrolledExperiment>,
     app_context: AppContext,
     db: Database,
-    id: Uuid,
+    nimbus_id: Uuid,
 }
 
 #[derive(Debug, Clone)]
@@ -53,14 +53,14 @@ impl NimbusClient {
         let client = Client::new(&collection_name, config.clone())?;
         let resp = client.get_experiments()?;
         let db = Database::new(db_path)?;
-        let id = Self::get_or_create_nimbus_id(&db)?;
-        let enrolled_experiments = evaluator::filter_enrolled(&id, &resp)?;
+        let nimbus_id = Self::get_or_create_nimbus_id(&db)?;
+        let enrolled_experiments = evaluator::filter_enrolled(&nimbus_id, &resp)?;
         Ok(Self {
             experiments: resp,
             enrolled_experiments,
             app_context,
             db,
-            id,
+            nimbus_id,
         })
     }
 
@@ -95,8 +95,6 @@ impl NimbusClient {
         unimplemented!()
     }
 
-    // TODO: do we want an accessor for `self.id` (which is either passed by config or the nimbus_id),
-    // or do we want a nimbus_id accessor? (what we have now).
     pub fn nimbus_id(&self) -> Result<Uuid> {
         Self::get_or_create_nimbus_id(&self.db)
     }

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -53,11 +53,7 @@ impl NimbusClient {
         let client = Client::new(&collection_name, config.clone())?;
         let resp = client.get_experiments()?;
         let db = Database::new(db_path)?;
-        let id = match config.map(|c| c.uuid).flatten() {
-            Some(ref uuid) => Uuid::parse_str(uuid)?,
-            None => Self::get_or_create_nimbus_id(&db)?,
-        };
-        log::info!("id is {}", id);
+        let id = Self::get_or_create_nimbus_id(&db)?;
         let enrolled_experiments = evaluator::filter_enrolled(&id, &resp)?;
         Ok(Self {
             experiments: resp,

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -14,7 +14,7 @@ mod sampling;
 pub use evaluator::filter_enrolled;
 
 use ::uuid::Uuid;
-pub use config::Config as ExperimentConfig;
+pub use config::Config;
 use http_client::{Client, SettingsClient};
 pub use matcher::AppContext;
 use persistence::Database;
@@ -48,7 +48,7 @@ impl NimbusClient {
         collection_name: String,
         app_context: AppContext,
         db_path: P,
-        config: Option<ExperimentConfig>,
+        config: Option<Config>,
     ) -> Result<Self> {
         let client = Client::new(&collection_name, config.clone())?;
         let resp = client.get_experiments()?;

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -25,6 +25,10 @@ dictionary Config {
     string? bucket_name;
 };
 
+dictionary AvailableRandomizationUnits {
+    string? client_id;
+};
+
 [Error]
 enum Error {
    "InvalidPersistedData", "RkvError", "IOError",
@@ -35,7 +39,13 @@ enum Error {
 
 interface NimbusClient {
     [Throws=Error]
-    constructor(string collection_name, AppContext app_ctx, string dbpath, Config? config);
+    constructor(
+        string collection_name,
+        AppContext app_ctx,
+        string dbpath,
+        Config? config,
+        AvailableRandomizationUnits available_randomization_units
+    );
 
 
     string? get_experiment_branch(string experiment_slug);

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -20,7 +20,7 @@ dictionary EnrolledExperiment {
     string branch_slug;
 };
 
-dictionary ExperimentConfig {
+dictionary Config {
     string? server_url;
     string? bucket_name;
 };
@@ -35,7 +35,7 @@ enum Error {
 
 interface NimbusClient {
     [Throws=Error]
-    constructor(string collection_name, AppContext app_ctx, string dbpath, ExperimentConfig? config);
+    constructor(string collection_name, AppContext app_ctx, string dbpath, Config? config);
 
 
     string? get_experiment_branch(string experiment_slug);

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -22,7 +22,6 @@ dictionary EnrolledExperiment {
 
 dictionary ExperimentConfig {
     string? server_url;
-    string? uuid;
     string? bucket_name;
 };
 

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -20,7 +20,7 @@ dictionary EnrolledExperiment {
     string branch_slug;
 };
 
-dictionary Config {
+dictionary RemoteSettingsConfig {
     string? server_url;
     string? bucket_name;
 };
@@ -43,7 +43,7 @@ interface NimbusClient {
         string collection_name,
         AppContext app_ctx,
         string dbpath,
-        Config? config,
+        RemoteSettingsConfig? remote_settings_config,
         AvailableRandomizationUnits available_randomization_units
     );
 


### PR DESCRIPTION
Fixes [NIBSSD-66](https://jira.mozilla.com/browse/NIBSSD-66) and [NIBSSD-67](https://jira.mozilla.com/browse/NIBSSD-67).

One of the main pieces of this patch is the introduction of `AvailableRandomizationUnits`, passed by the app at initialization time, which allows experiments to have a custom bucketing strategy.