### PR TITLE
Add a 'file system' client and update the experiment cmdline app

### DIFF
--- a/nimbus/src/client/fs_client.rs
+++ b/nimbus/src/client/fs_client.rs
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! A SettingsClient that uses the file-system. Used for developer ergonomics
+//! (eg, for testing against experiments which are not deployed anywhere) and
+//! for tests.
+
+use crate::error::Result;
+use crate::Experiment;
+use crate::SettingsClient;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+
+pub struct FileSystemClient {
+    path: PathBuf,
+}
+
+impl FileSystemClient {
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
+        Ok(Self {
+            path: path.as_ref().into(),
+        })
+    }
+}
+
+impl SettingsClient for FileSystemClient {
+    fn get_experiments_metadata(&self) -> Result<String> {
+        unimplemented!();
+    }
+
+    fn get_experiments(&self) -> Result<Vec<Experiment>> {
+        log::info!("reading experiments in {}", self.path.display());
+        let mut res = Vec::new();
+        // Skip directories and non .json files (eg, READMEs)
+        let json_ext = Some(OsStr::new("json"));
+        let filenames = self
+            .path
+            .read_dir()?
+            .filter_map(Result::ok)
+            .map(|c| c.path())
+            .filter(|f| f.is_file() && f.extension() == json_ext);
+        for child_path in filenames {
+            let file = File::open(child_path.clone())?;
+            let reader = BufReader::new(file);
+            match serde_json::from_reader::<_, Experiment>(reader) {
+                Ok(exp) => res.push(exp),
+                Err(e) => {
+                    log::warn!(
+                        "Malformed experiment found! File {},  Error: {}",
+                        child_path.display(),
+                        e
+                    );
+                }
+            }
+        }
+        Ok(res)
+    }
+}

--- a/nimbus/src/client/mod.rs
+++ b/nimbus/src/client/mod.rs
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+mod fs_client;
+mod http_client;
+use crate::error::{Error, Result};
+use crate::Experiment;
+use crate::RemoteSettingsConfig;
+use fs_client::FileSystemClient;
+use http_client::Client;
+use url::Url;
+
+pub(crate) fn create_client(
+    config: RemoteSettingsConfig,
+) -> Result<Box<dyn SettingsClient + Send>> {
+    // XXX - double-parsing the URL here if it's not a file:// URL - ideally
+    // config would already be holding a Url and we wouldn't parse here at all.
+    let url = Url::parse(&config.server_url)?;
+    Ok(if url.scheme() == "file" {
+        // Everything in `config` other than the url/path is ignored for the
+        // file-system - we could insist on a sub-directory, but that doesn't
+        // seem valuable for the use-cases we care about here.
+        let path = match url.to_file_path() {
+            Ok(path) => path,
+            _ => return Err(Error::InvalidPath(config.server_url)),
+        };
+        Box::new(FileSystemClient::new(path)?)
+    } else {
+        Box::new(Client::new(config)?)
+    })
+}
+
+// The trait used to fetch experiments.
+pub(crate) trait SettingsClient {
+    fn get_experiments_metadata(&self) -> Result<String>;
+    fn get_experiments(&self) -> Result<Vec<Experiment>>;
+}

--- a/nimbus/src/error.rs
+++ b/nimbus/src/error.rs
@@ -38,6 +38,8 @@ pub enum Error {
     ResponseError(String),
     #[error("Invalid experiments response received")]
     InvalidExperimentResponse,
+    #[error("Invalid path: {0}")]
+    InvalidPath(String),
 }
 
 // This can be replaced with #[from] in the enum definition

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -35,7 +35,8 @@ enum Error {
    "InvalidPersistedData", "RkvError", "IOError",
    "JSONError", "EvaluationError", "InvalidExpression", "InvalidFraction",
     "TryFromSliceError", "EmptyRatiosError", "OutOfBoundsError","UrlParsingError",
-    "RequestError", "ResponseError", "UuidError", "InvalidExperimentResponse"
+    "RequestError", "ResponseError", "UuidError", "InvalidExperimentResponse",
+    "InvalidPath"
 };
 
 interface NimbusClient {

--- a/nimbus/tests/experiments/README.md
+++ b/nimbus/tests/experiments/README.md
@@ -1,0 +1,6 @@
+This directory contains experiments as JSON files.
+
+test_fs_client.rs has some simple tests which use this directory.
+You can also configure nimbus with a file:// URL pointing
+at this directory and it will "do the right thing". Feel
+free to add more interesting experiments here.

--- a/nimbus/tests/experiments/invalid-experiment-missing-slug.json
+++ b/nimbus/tests/experiments/invalid-experiment-missing-slug.json
@@ -1,0 +1,30 @@
+{
+  "endDate": null,
+  "branches": [
+    {
+      "slug": "control",
+      "ratio": 1
+    },
+    {
+      "slug": "treatment",
+      "ratio": 1
+    }
+  ],
+  "probeSets": [],
+  "startDate": null,
+  "application": "fenix",
+  "bucketConfig": {
+    "count": 10000,
+    "start": 0,
+    "total": 10000,
+    "namespace": "invalid",
+    "randomizationUnit": "nimbus_id"
+  },
+  "userFacingName": "Diagnostic test experiment",
+  "referenceBranch": "control",
+  "isEnrollmentPaused": false,
+  "proposedEnrollment": 7,
+  "userFacingDescription": "This is an invalid experiment.",
+  "id": "secure-gold",
+  "last_modified": 1602197324372
+}

--- a/nimbus/tests/experiments/secure-gold.json
+++ b/nimbus/tests/experiments/secure-gold.json
@@ -1,0 +1,31 @@
+{
+  "slug": "secure-gold",
+  "endDate": null,
+  "branches": [
+    {
+      "slug": "control",
+      "ratio": 1
+    },
+    {
+      "slug": "treatment",
+      "ratio": 1
+    }
+  ],
+  "probeSets": [],
+  "startDate": null,
+  "application": "fenix",
+  "bucketConfig": {
+    "count": 10000,
+    "start": 0,
+    "total": 10000,
+    "namespace": "secure-gold",
+    "randomizationUnit": "nimbus_id"
+  },
+  "userFacingName": "Diagnostic test experiment",
+  "referenceBranch": "control",
+  "isEnrollmentPaused": false,
+  "proposedEnrollment": 7,
+  "userFacingDescription": "This is a test experiment for diagnostic purposes.",
+  "id": "secure-gold",
+  "last_modified": 1602197324372
+}

--- a/nimbus/tests/test_fs_client.rs
+++ b/nimbus/tests/test_fs_client.rs
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Simple tests for our file-system client
+
+use nimbus::{error::Result, AvailableRandomizationUnits, NimbusClient, RemoteSettingsConfig};
+use std::path::PathBuf;
+use tempdir::TempDir;
+use url::Url;
+
+#[test]
+fn test_simple() -> Result<()> {
+    let _ = env_logger::try_init();
+
+    let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    dir.push("tests/experiments");
+
+    let url = Url::from_file_path(dir).expect("experiments dir should exist");
+
+    let config = RemoteSettingsConfig {
+        server_url: url.as_str().to_string(),
+        collection_name: "doesn't matter".to_string(),
+        bucket_name: "doesn't matter".to_string(),
+    };
+
+    let tmp_dir = TempDir::new("test_fs_client-test_simple")?;
+
+    let aru = AvailableRandomizationUnits { client_id: None };
+    let client = NimbusClient::new(Default::default(), tmp_dir.path(), config, aru)?;
+
+    let experiments = client.get_all_experiments()?;
+    assert_eq!(experiments.len(), 1);
+    assert_eq!(experiments[0].slug, "secure-gold");
+    // Once we can set the nimbus ID, we should set it to a uuid we know
+    // gets enrolled.
+    Ok(())
+}


### PR DESCRIPTION
This PR adds a "file system" client, intended for developers (and later, I suspect it will be used for tests). I ended up splitting the other stuff out into their own PRs.

If the `server_url` is a `file://` URL, the new "file system client" will be used. In this case, we expect the URL to point to a directory, and we will serve up the .json files as experiment. Also includes a directory where we can start to accumulate "useful" experiments and a test.