### PR TITLE
A bit of a straw-man for how persistence might work.

### DIFF
--- a/nimbus/Cargo.lock
+++ b/nimbus/Cargo.lock
@@ -450,6 +450,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,7 +923,7 @@ dependencies = [
  "httparse",
  "lazy_static",
  "log",
- "rand",
+ "rand 0.7.3",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -975,6 +981,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha2 0.9.1",
+ "tempdir",
  "thiserror",
  "uniffi",
  "uniffi_build",
@@ -1237,6 +1244,19 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -1244,7 +1264,7 @@ dependencies = [
  "getrandom",
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.5.1",
  "rand_hc",
 ]
 
@@ -1255,8 +1275,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1273,7 +1308,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1583,6 +1627,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,7 +1644,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if",
  "libc",
- "rand",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -1832,7 +1886,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 dependencies = [
- "rand",
+ "rand 0.7.3",
  "serde",
 ]
 

--- a/nimbus/Cargo.toml
+++ b/nimbus/Cargo.toml
@@ -39,3 +39,4 @@ viaduct-reqwest = { git = "https://github.com/mozilla/application-services",  re
 mockito = "0.27"
 env_logger = "0.7"
 clap = "2.33.3"
+tempdir = "0.3"

--- a/nimbus/examples/config/config.json
+++ b/nimbus/examples/config/config.json
@@ -1,6 +1,5 @@
 {
     "context": {"app_id": "101010", "locale": "en-US"},
-    "collection_name": "messaging-experiments",
-    "bucket_name": "main",
-    "uuid": "d7bb442c-81ef-4d0d-bd14-fedb3b67ccd4"
+    "collection_name": "nimbus-mobile-experiments",
+    "bucket_name": "main"
 }

--- a/nimbus/src/enrollment.rs
+++ b/nimbus/src/enrollment.rs
@@ -1,0 +1,327 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use crate::error::Result;
+use crate::evaluator::evaluate_enrollment;
+use crate::persistence::{Database, StoreId};
+use crate::AvailableRandomizationUnits;
+use crate::{AppContext, EnrolledExperiment, Experiment};
+
+use ::uuid::Uuid;
+use serde_derive::*;
+use std::collections::{HashMap, HashSet};
+
+// These are types we use internally for managing enrollments.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub enum EnrolledReason {
+    Qualified, // A normal enrollment as per the experiment's rules.
+    OptIn,     // Explicit opt-in.
+}
+
+// Every experiment has an ExperimentEnrollment, even when we aren't enrolled.
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub struct ExperimentEnrollment {
+    pub slug: String,
+    pub status: EnrollmentStatus,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+pub enum EnrollmentStatus {
+    // Enrolled
+    Enrolled {
+        reason: EnrolledReason,
+        branch: String,
+    },
+    // Not enrolled because our evaluator declined to choose us.
+    NotSelected,
+    // Not enrolled because either enrollment is paused or the experiment is over.
+    NotRunning,
+    // Not enrolled because we are not being targeted for this experiment.
+    NotTargeted,
+    // User explicitly opted out.
+    OptedOut,
+    // There was some error opting in.
+    Error {
+        // Ideally this would be an Error, but then we'd need to make Error
+        // serde compatible, which isn't trivial nor desirable.
+        reason: String,
+    },
+}
+
+/// Return information about all enrolled experiments.
+pub fn get_enrollments(db: &Database) -> Result<Vec<EnrolledExperiment>> {
+    let enrollments: Vec<ExperimentEnrollment> = db.collect_all(StoreId::Enrollments)?;
+    let mut result = Vec::with_capacity(enrollments.len());
+    for enrollment in enrollments {
+        log::debug!("Have enrollment: {:?}", enrollment);
+        if let EnrollmentStatus::Enrolled { ref branch, .. } = enrollment.status {
+            if let Some(experiment) =
+                db.get::<Experiment>(StoreId::Experiments, &enrollment.slug)?
+            {
+                result.push(EnrolledExperiment {
+                    slug: experiment.slug,
+                    user_facing_name: experiment.user_facing_name,
+                    user_facing_description: experiment.user_facing_description,
+                    branch_slug: branch.to_string(),
+                });
+            } else {
+                log::warn!(
+                    "Have enrollment {:?} but no matching experiment!",
+                    enrollment
+                );
+            }
+        }
+    }
+    Ok(result)
+}
+
+/// Update all enrollments. Typically used immediately after the list of
+/// experiments has been refreshed, so some might mean new enrollments, some
+/// might have expired, etc.
+pub fn update_enrollments(
+    db: &Database,
+    nimbus_id: &Uuid,
+    aru: &AvailableRandomizationUnits,
+    app_context: &AppContext,
+) -> Result<()> {
+    log::info!("updating enrollments...");
+    // We might have enrollments for experiments which no longer exist, so we
+    // first build a set of all IDs in both groups.
+    let mut all_slugs = HashSet::new();
+    let experiments = db.collect_all::<Experiment>(StoreId::Experiments)?;
+    let mut map_experiments = HashMap::with_capacity(experiments.len());
+    for e in experiments {
+        all_slugs.insert(e.slug.clone());
+        map_experiments.insert(e.slug.clone(), e);
+    }
+    // and existing enrollments.
+    let enrollments = db.collect_all::<ExperimentEnrollment>(StoreId::Enrollments)?;
+    let mut map_enrollments = HashMap::with_capacity(enrollments.len());
+    for e in enrollments {
+        all_slugs.insert(e.slug.clone());
+        map_enrollments.insert(e.slug.clone(), e);
+    }
+
+    // XXX - we want to emit events for many of these things, but we are hoping
+    // we can put that off until we have a glean rust sdk available and thus
+    // avoid the complexity of passing the info to glean via kotlin/swift/js.
+    for slug in all_slugs.iter() {
+        match (map_experiments.get(slug), map_enrollments.get(slug)) {
+            (Some(_), Some(enr)) => {
+                // XXX - should check:
+                // * is it still active?
+                // * is enrollment was previously paused it may not be now.
+                // * the branch still exists, etc?
+                log::debug!("Experiment '{}' already has enrollment {:?}", slug, enr)
+            }
+            (Some(exp), None) => {
+                let enr = evaluate_enrollment(nimbus_id, aru, app_context, &exp)?;
+                log::debug!(
+                    "Experiment '{}' is new - enrollment status is {:?}",
+                    slug,
+                    enr
+                );
+                db.put(StoreId::Enrollments, slug, &enr)?;
+            }
+            (None, Some(enr)) => {
+                log::debug!(
+                    "Experiment '{}' vanished while we had enrollment status of {:?}",
+                    slug,
+                    enr
+                );
+                db.delete(StoreId::Enrollments, slug)?;
+            }
+            _ => unreachable!(),
+        }
+    }
+    Ok(())
+}
+
+/// Resets an experiment to remove any opt-in or opt-out overrides.
+pub fn reset_enrollment(
+    db: &Database,
+    experiment_slug: &str,
+    nimbus_id: &Uuid,
+    aru: &AvailableRandomizationUnits,
+    app_context: &AppContext,
+) -> Result<()> {
+    let exp = match db.get::<Experiment>(StoreId::Experiments, experiment_slug)? {
+        None => {
+            // XXX - do we want specific errors for this kind of thing?
+            log::warn!("No such experiment '{}'", experiment_slug);
+            return Ok(());
+        }
+        Some(e) => e,
+    };
+    let enrollment = evaluate_enrollment(nimbus_id, aru, app_context, &exp)?;
+    db.put(StoreId::Enrollments, experiment_slug, &enrollment)
+}
+
+pub fn opt_in_with_branch(db: &Database, experiment_slug: &str, branch: &str) -> Result<()> {
+    // For now we don't bother checking if the experiment or branch exist - if
+    // they don't the enrollment will just be removed next time we refresh.
+    let enrollment = ExperimentEnrollment {
+        slug: experiment_slug.to_string(),
+        status: EnrollmentStatus::Enrolled {
+            reason: EnrolledReason::OptIn,
+            branch: branch.to_string(),
+        },
+    };
+    db.put(StoreId::Enrollments, experiment_slug, &enrollment)
+}
+
+pub fn opt_out(db: &Database, experiment_slug: &str) -> Result<()> {
+    // As above - check experiment exists?
+    let enrollment = ExperimentEnrollment {
+        slug: experiment_slug.to_string(),
+        status: EnrollmentStatus::OptedOut,
+    };
+    db.put(StoreId::Enrollments, experiment_slug, &enrollment)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persistence::{Database, StoreId};
+    use crate::AvailableRandomizationUnits;
+    use serde_json::json;
+    use tempdir::TempDir;
+
+    fn get_test_experiments() -> Vec<serde_json::Value> {
+        vec![
+            json!({
+                "slug": "secure-gold",
+                "endDate": null,
+                "branches":[
+                    {"slug": "control", "ratio": 1},
+                    {"slug": "treatment","ratio":1}
+                ],
+                "probeSets":[],
+                "startDate":null,
+                "application":"fenix",
+                "bucketConfig":{
+                    // Setup to enroll everyone by default.
+                    "count":10_000,
+                    "start":0,
+                    "total":10_000,
+                    "namespace":"secure-gold",
+                    "randomizationUnit":"nimbus_id"
+                },
+                "userFacingName":"Diagnostic test experiment",
+                "referenceBranch":"control",
+                "isEnrollmentPaused":false,
+                "proposedEnrollment":7,
+                "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+                "id":"secure-gold",
+                "last_modified":1_602_197_324_372i64
+            }),
+            json!({
+                "slug": "secure-silver",
+                "endDate": null,
+                "branches":[
+                    {"slug": "control", "ratio": 1},
+                    {"slug": "treatment","ratio":1}
+                ],
+                "probeSets":[],
+                "startDate":null,
+                "application":"fenix",
+                "bucketConfig":{
+                    // Also enroll everyone.
+                    "count":10_000,
+                    "start":0,
+                    "total":10_000,
+                    "namespace":"secure-silver",
+                    "randomizationUnit":"nimbus_id"
+                },
+                "userFacingName":"2nd test experiment",
+                "referenceBranch":"control",
+                "isEnrollmentPaused":false,
+                "proposedEnrollment":7,
+                "userFacingDescription":"2nd test experiment.",
+                "id":"secure-silver",
+                "last_modified":1_602_197_324_372i64
+            }),
+        ]
+    }
+
+    #[test]
+    fn test_enrollments() -> Result<()> {
+        let _ = env_logger::try_init();
+        let tmp_dir = TempDir::new("test_enrollments")?;
+        let db = Database::new(&tmp_dir)?;
+        let exp = &get_test_experiments()[0];
+        let nimbus_id = Uuid::new_v4();
+        let aru = AvailableRandomizationUnits { client_id: None };
+        assert_eq!(get_enrollments(&db)?.len(), 0);
+        db.put(
+            StoreId::Experiments,
+            exp.get("slug").unwrap().as_str().unwrap(),
+            exp,
+        )?;
+        update_enrollments(&db, &nimbus_id, &aru, &Default::default())?;
+        let enrollments = get_enrollments(&db)?;
+        assert_eq!(enrollments.len(), 1);
+        let enrollment = &enrollments[0];
+        assert_eq!(enrollment.slug, "secure-gold");
+        assert_eq!(enrollment.user_facing_name, "Diagnostic test experiment");
+        assert_eq!(
+            enrollment.user_facing_description,
+            "This is a test experiment for diagnostic purposes."
+        );
+        assert!(enrollment.branch_slug == "control" || enrollment.branch_slug == "treatment");
+
+        // Get the ExperimentEnrollment from the DB.
+        let ee = db
+            .get::<ExperimentEnrollment>(StoreId::Enrollments, "secure-gold")?
+            .expect("should exist");
+        assert!(
+            matches!(ee.status, EnrollmentStatus::Enrolled { reason: EnrolledReason::Qualified, .. })
+        );
+
+        // Now opt-out.
+        opt_out(&db, "secure-gold")?;
+        assert_eq!(get_enrollments(&db)?.len(), 0);
+        // check we recorded the "why" correctly.
+        let ee = db
+            .get::<ExperimentEnrollment>(StoreId::Enrollments, "secure-gold")?
+            .expect("should exist");
+        assert_eq!(ee.status, EnrollmentStatus::OptedOut);
+
+        // Opt in to a specific branch.
+        opt_in_with_branch(&db, "secure-gold", "treatment")?;
+        let enrollments = get_enrollments(&db)?;
+        assert_eq!(enrollments.len(), 1);
+        let enrollment = &enrollments[0];
+        assert_eq!(enrollment.slug, "secure-gold");
+        assert!(enrollment.branch_slug == "treatment");
+        Ok(())
+    }
+
+    #[test]
+    fn test_updates() -> Result<()> {
+        let _ = env_logger::try_init();
+        let tmp_dir = TempDir::new("test_updates")?;
+        let db = Database::new(&tmp_dir)?;
+        let nimbus_id = Uuid::new_v4();
+        let aru = AvailableRandomizationUnits { client_id: None };
+        assert_eq!(get_enrollments(&db)?.len(), 0);
+        let exps = get_test_experiments();
+        for exp in exps {
+            db.put(
+                StoreId::Experiments,
+                exp.get("slug").unwrap().as_str().unwrap(),
+                &exp,
+            )?;
+        }
+        update_enrollments(&db, &nimbus_id, &aru, &Default::default())?;
+        let enrollments = get_enrollments(&db)?;
+        assert_eq!(enrollments.len(), 2);
+        // pretend we just updated from the server and one of the 2 is missing.
+        db.delete(StoreId::Experiments, "secure-gold")?;
+        update_enrollments(&db, &nimbus_id, &aru, &Default::default())?;
+        // should only have 1 now.
+        let enrollments = get_enrollments(&db)?;
+        assert_eq!(enrollments.len(), 1);
+        Ok(())
+    }
+}

--- a/nimbus/src/error.rs
+++ b/nimbus/src/error.rs
@@ -16,9 +16,9 @@ pub enum Error {
     IOError(#[from] std::io::Error),
     #[error("JSON Error: {0}")]
     JSONError(#[from] serde_json::Error),
-    #[error("EvaluationError")]
-    EvaluationError,
-    #[error("Invalid Expression")]
+    #[error("EvaluationError: {0}")]
+    EvaluationError(String),
+    #[error("Invalid Expression - didn't evaluate to a bool")]
     InvalidExpression,
     #[error("InvalidFractionError: Should be between 0 and 1")]
     InvalidFraction,
@@ -49,9 +49,8 @@ impl From<rkv::StoreError> for Error {
 }
 
 impl<'a> From<jexl_eval::error::EvaluationError<'a>> for Error {
-    fn from(_eval_error: jexl_eval::error::EvaluationError<'a>) -> Self {
-        // TODO: have the eval_error as a part of our error
-        Error::EvaluationError
+    fn from(eval_error: jexl_eval::error::EvaluationError<'a>) -> Self {
+        Error::EvaluationError(eval_error.to_string())
     }
 }
 

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+mod enrollment;
 pub mod error;
 mod evaluator;
 pub use error::{Error, Result};
@@ -11,13 +12,16 @@ mod matcher;
 mod persistence;
 mod sampling;
 #[cfg(debug_assertions)]
-pub use evaluator::filter_enrolled;
+pub use evaluator::evaluate_enrollment;
 
 use ::uuid::Uuid;
 pub use config::RemoteSettingsConfig;
+use enrollment::{
+    get_enrollments, opt_in_with_branch, opt_out, reset_enrollment, update_enrollments,
+};
 use http_client::{Client, SettingsClient};
 pub use matcher::AppContext;
-use persistence::Database;
+use persistence::{Database, StoreId};
 use serde_derive::*;
 use std::path::Path;
 
@@ -28,19 +32,11 @@ const DB_KEY_NIMBUS_ID: &str = "nimbus-id";
 /// It should hold all the information needed to communicate a specific user's
 /// experimentation status
 pub struct NimbusClient {
-    experiments: Vec<Experiment>,
-    enrolled_experiments: Vec<EnrolledExperiment>,
+    http_client: Client,
+    available_randomization_units: AvailableRandomizationUnits,
     app_context: AppContext,
     db: Database,
     nimbus_id: Uuid,
-}
-
-#[derive(Debug, Clone)]
-pub struct EnrolledExperiment {
-    pub slug: String,
-    pub user_facing_name: String,
-    pub user_facing_description: String,
-    pub branch_slug: String,
 }
 
 impl NimbusClient {
@@ -51,50 +47,87 @@ impl NimbusClient {
         config: Option<RemoteSettingsConfig>,
         available_randomization_units: AvailableRandomizationUnits,
     ) -> Result<Self> {
-        let client = Client::new(&collection_name, config.clone())?;
-        let resp = client.get_experiments()?;
+        let http_client = Client::new(&collection_name, config)?;
         let db = Database::new(db_path)?;
         let nimbus_id = Self::get_or_create_nimbus_id(&db)?;
-        let enrolled_experiments =
-            evaluator::filter_enrolled(&nimbus_id, &available_randomization_units, &resp)?;
         Ok(Self {
-            experiments: resp,
-            enrolled_experiments,
+            http_client,
+            available_randomization_units,
             app_context,
             db,
             nimbus_id,
         })
     }
 
-    pub fn get_experiment_branch(&self, slug: String) -> Option<String> {
-        self.enrolled_experiments
+    // This is a little suspect but it's not clear what the right thing is.
+    // Maybe it's OK we initially start with no experiments and just need to
+    // wait for the app to schedule a regular `update_experiments()` call?
+    // But for now, if we have no experiments we assume we have never
+    // successfully hit our server, so should do that now.
+    fn maybe_initial_experiment_fetch(&self) -> Result<()> {
+        if !self.db.has_any(StoreId::Experiments)? {
+            log::info!("No experiments in our database - fetching them");
+            self.update_experiments()?;
+        }
+        Ok(())
+    }
+
+    pub fn get_experiment_branch(&self, slug: String) -> Result<Option<String>> {
+        Ok(self
+            .get_active_experiments()?
             .iter()
             .find(|e| e.slug == slug)
-            .map(|e| e.branch_slug.clone())
+            .map(|e| e.branch_slug.clone()))
     }
 
-    pub fn get_active_experiments(&self) -> Vec<EnrolledExperiment> {
-        self.enrolled_experiments.clone()
+    pub fn get_active_experiments(&self) -> Result<Vec<EnrolledExperiment>> {
+        self.maybe_initial_experiment_fetch()?;
+        get_enrollments(&self.db)
     }
 
-    pub fn get_all_experiments(&self) -> Vec<Experiment> {
-        self.experiments.clone()
+    pub fn get_all_experiments(&self) -> Result<Vec<Experiment>> {
+        self.maybe_initial_experiment_fetch()?;
+        self.db.collect_all(StoreId::Experiments)
     }
 
-    pub fn opt_in_with_branch(&self, _experiment_slug: String, _branch: String) {
-        unimplemented!()
+    pub fn opt_in_with_branch(&self, experiment_slug: String, branch: String) -> Result<()> {
+        opt_in_with_branch(&self.db, &experiment_slug, &branch)
     }
 
-    pub fn opt_out(&self, _experiment_slug: String) {
-        unimplemented!()
+    pub fn opt_out(&self, experiment_slug: String) -> Result<()> {
+        opt_out(&self.db, &experiment_slug)
     }
 
-    pub fn opt_out_all(&self) {
-        unimplemented!()
+    pub fn reset_enrollment(&self, experiment_slug: String) -> Result<()> {
+        reset_enrollment(
+            &self.db,
+            &experiment_slug,
+            &self.nimbus_id,
+            &self.available_randomization_units,
+            &self.app_context,
+        )
     }
 
     pub fn update_experiments(&self) -> Result<()> {
-        unimplemented!()
+        // I suspect we need to take some action when we find experiments we
+        // previously had no longer exist? For now though, just nuke them all.
+        log::info!("updating experiment list");
+        let experiments = self.http_client.get_experiments()?;
+        // XXX - we need transaction support but it's not clear how to expose
+        // that support.
+        self.db.clear(StoreId::Experiments)?;
+        for experiment in experiments {
+            log::debug!("found experiment {}", experiment.slug);
+            self.db
+                .put(StoreId::Experiments, &experiment.slug, &experiment)?;
+        }
+        // Now update all enrollments based on the new set.
+        update_enrollments(
+            &self.db,
+            &self.nimbus_id,
+            &self.available_randomization_units,
+            &self.app_context,
+        )
     }
 
     pub fn nimbus_id(&self) -> Uuid {
@@ -102,15 +135,23 @@ impl NimbusClient {
     }
 
     fn get_or_create_nimbus_id(db: &Database) -> Result<Uuid> {
-        Ok(match db.get(DB_KEY_NIMBUS_ID)? {
+        Ok(match db.get(StoreId::Meta, DB_KEY_NIMBUS_ID)? {
             Some(nimbus_id) => nimbus_id,
             None => {
                 let nimbus_id = Uuid::new_v4();
-                db.put(DB_KEY_NIMBUS_ID, &nimbus_id)?;
+                db.put(StoreId::Meta, DB_KEY_NIMBUS_ID, &nimbus_id)?;
                 nimbus_id
             }
         })
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct EnrolledExperiment {
+    pub slug: String,
+    pub user_facing_name: String,
+    pub user_facing_description: String,
+    pub branch_slug: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -48,14 +48,35 @@ interface NimbusClient {
     );
 
 
+    // Returns the branch allocated for a given experiment ID. Returns null
+    // if the user is not enrolled in the specified experiment or if the
+    // specified experiment does not exist.
+    [Throws=Error]
     string? get_experiment_branch(string experiment_slug);
 
+    // Returns a list of experiments this user is enrolled in.
+    [Throws=Error]
     sequence<EnrolledExperiment> get_active_experiments();
 
-    void opt_in_with_branch(string experiment_slug, string branch);
-    void opt_out(string experiment_slug);
-    void opt_out_all();
-
+    // Updates the list of experiments from the server. After calling this, the
+    // list of active experiments might change (there might be new experiments,
+    // or old experiments might have expired)
     [Throws=Error]
     void update_experiments();
+
+    // These are test-only functions and should never be exposed to production
+    // users, as they mess with the "statistical requirements" of the SDK.
+
+    // Opt in to a specific branch on a specific experiment. Useful for
+    // developers to test their app's interaction with the experiment.
+    [Throws=Error]
+    void opt_in_with_branch(string experiment_slug, string branch);
+
+    // Opt out of a specific experiment.
+    [Throws=Error]
+    void opt_out(string experiment_slug);
+
+    [Throws=Error]
+    void reset_enrollment(string experiment_slug);
+
 };


### PR DESCRIPTION
    Wire up persistence of enrolled experiments.

    * experiments and enrollment status are all stored in the DB. Only
      fetches experiments in the constructor if there are none in the DB,
      which doesn't smell like the right thing long term - otherwise though,
      you must explicitly call `update_experiments()`. We should work out
      what behaviour makes sense for apps here.

    * Fully implements the `opt_out` etc methods. Any experiment can be opted in
      to and opted out of, with this stored in the DB. Calling
      `update_experiments()` will not change the opted-on/out status - there's
      a new 'reset_enrollment` function that does though. Note that opting
      out is fully supported, but the expectation is that this must only be
      used in a dev or test context.

    * When `update_experiments()` is called, enrollments for experiments
      which no longer exist are removed, and new experiments are evaluated
      for enrollment. We don't emit any events yet, but we could. We do log
      so you can see things happening. We don't support experiments being paused,
      nor start and end dates for experiments, etc.

    * It allows you to opt in/out/etc to non-existing experiments - but they will
      be removed when `update_experiments()` is called (ie, it's treated as
      though the experiment was removed. We could fix this, but meh.

    * Out command-line utility `experiment.rs` supports all of this - use --help.

[edited to reflect current commit message]