### PR TITLE
Make RemoteSettingsConfig and the server URL inside it non-optional

### DIFF
--- a/nimbus/src/config.rs
+++ b/nimbus/src/config.rs
@@ -14,6 +14,7 @@
 /// - `bucket_name`: The name of the bucket containing the collection on the server
 #[derive(Debug, Clone)]
 pub struct RemoteSettingsConfig {
-    pub server_url: Option<String>,
-    pub bucket_name: Option<String>,
+    pub server_url: String,
+    pub collection_name: String,
+    pub bucket_name: String,
 }

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -44,13 +44,12 @@ impl NimbusClient {
     // This constructor *must* not do any kind of I/O since it might be called on the main
     // thread in the gecko Javascript stack, hence the use of OnceCell for the db.
     pub fn new<P: Into<PathBuf>>(
-        collection_name: String,
         app_context: AppContext,
         db_path: P,
-        config: Option<RemoteSettingsConfig>,
+        config: RemoteSettingsConfig,
         available_randomization_units: AvailableRandomizationUnits,
     ) -> Result<Self> {
-        let http_client = Client::new(&collection_name, config)?;
+        let http_client = Client::new(config)?;
         Ok(Self {
             http_client,
             available_randomization_units,

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -21,8 +21,9 @@ dictionary EnrolledExperiment {
 };
 
 dictionary RemoteSettingsConfig {
-    string? server_url;
-    string? bucket_name;
+    string server_url;
+    string collection_name;
+    string bucket_name;
 };
 
 dictionary AvailableRandomizationUnits {
@@ -40,10 +41,9 @@ enum Error {
 interface NimbusClient {
     [Throws=Error]
     constructor(
-        string collection_name,
         AppContext app_ctx,
         string dbpath,
-        RemoteSettingsConfig? remote_settings_config,
+        RemoteSettingsConfig remote_settings_config,
         AvailableRandomizationUnits available_randomization_units
     );
 


### PR DESCRIPTION
I split this from #38 mainly for ease of review. Note that @rfk and I discussed adding constants for the default server URLs, but given the discussion started by @jhugman it's not clear yet that is actually desirable - string constants in the consuming code are probably less likely to be overlooked than, eg, `Servers.RELEASE`

Explicitly flagging @travis79 for review as it will (somewhat trivially) break his a-c PR.

