### PR TITLE
Add some enhancements to the 'experiment' example

### DIFF
--- a/nimbus/examples/config/config.json
+++ b/nimbus/examples/config/config.json
@@ -1,5 +1,5 @@
 {
     "context": {"app_id": "101010", "locale": "en-US"},
     "collection_name": "nimbus-mobile-experiments",
-    "bucket_name": "main"
+    "client_id": "{2204ac0e-1428-11eb-adc1-0242ac120002}"
 }

--- a/nimbus/examples/config/rapid-release-control.json
+++ b/nimbus/examples/config/rapid-release-control.json
@@ -1,6 +1,0 @@
-{
-    "context": {},
-    "collection_name": "messaging-experiments",
-    "bucket_name": "main",
-    "uuid": "31815303-5993-4897-b147-e1f575dc703f"
-}

--- a/nimbus/examples/config/rapid-rutabagas-treatment.json
+++ b/nimbus/examples/config/rapid-rutabagas-treatment.json
@@ -1,6 +1,0 @@
-{
-    "context": {},
-    "collection_name": "messaging-experiments",
-    "bucket_name": "main",
-    "uuid": "b78af688-2465-48ae-80ee-c98fd8e34825"
-}

--- a/nimbus/src/enrollment.rs
+++ b/nimbus/src/enrollment.rs
@@ -12,7 +12,7 @@ use serde_derive::*;
 use std::collections::{HashMap, HashSet};
 
 // These are types we use internally for managing enrollments.
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Hash, Eq, PartialEq)]
 pub enum EnrolledReason {
     Qualified, // A normal enrollment as per the experiment's rules.
     OptIn,     // Explicit opt-in.
@@ -25,7 +25,7 @@ pub struct ExperimentEnrollment {
     pub status: EnrollmentStatus,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Hash, Eq, PartialEq)]
 pub enum EnrollmentStatus {
     // Enrolled
     Enrolled {
@@ -46,6 +46,15 @@ pub enum EnrollmentStatus {
         // serde compatible, which isn't trivial nor desirable.
         reason: String,
     },
+}
+
+impl EnrollmentStatus {
+    pub fn is_enrolled(&self) -> bool {
+        match self {
+            EnrollmentStatus::Enrolled { .. } => true,
+            _ => false,
+        }
+    }
 }
 
 /// Return information about all enrolled experiments.

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -142,6 +142,13 @@ impl NimbusClient {
         })
     }
 
+    // Sets the nimbus ID - TEST ONLY - should not be exposed to real clients.
+    // (Useful for testing so you can have some control over what experiments
+    // are enrolled)
+    pub fn set_nimbus_id(&self, uuid: &Uuid) -> Result<()> {
+        self.db()?.put(StoreId::Meta, DB_KEY_NIMBUS_ID, uuid)
+    }
+
     fn db(&self) -> Result<&Database> {
         self.db.get_or_try_init(|| Database::new(&self.db_path))
     }


### PR DESCRIPTION
* Reinstates the `gen-uuid` command, and optionally sets
  the discovered uuid in the database. Also shows progress
  so you can see if you are in a loop that's likely to never
  complete.

* Adds a `brute-force` command which shows how any number of enrollments
  actually ends up being distributed.