### PR TITLE
Make AvailableRandomizationUnits.client_id optional and add a dummy field, reverting #45

### DIFF
--- a/nimbus/examples/experiment.rs
+++ b/nimbus/examples/experiment.rs
@@ -205,9 +205,7 @@ fn main() -> Result<()> {
         bucket_name: bucket_name.to_string(),
     };
 
-    let aru = AvailableRandomizationUnits {
-        client_id: client_id.clone(),
-    };
+    let aru = AvailableRandomizationUnits::with_client_id(&client_id);
 
     // Here we initialize our main `NimbusClient` struct
     let nimbus_client = NimbusClient::new(context, "", config, aru)?;
@@ -282,7 +280,7 @@ fn main() -> Result<()> {
             }
 
             let mut num_tries = 0;
-            let aru = AvailableRandomizationUnits { client_id };
+            let aru = AvailableRandomizationUnits::with_client_id(&client_id);
             'outer: loop {
                 let uuid = uuid::Uuid::new_v4();
                 let mut num_of_experiments_enrolled = 0;
@@ -340,9 +338,7 @@ fn main() -> Result<()> {
                 // by the experiment just generate a new uuid for all possible
                 // options.
                 let uuid = uuid::Uuid::new_v4();
-                let aru = AvailableRandomizationUnits {
-                    client_id: uuid.to_string(),
-                };
+                let aru = AvailableRandomizationUnits::with_client_id(&client_id);
                 let enrollment =
                     nimbus::evaluate_enrollment(&uuid, &aru, &Default::default(), &exp)?;
                 results.insert(

--- a/nimbus/src/enrollment.rs
+++ b/nimbus/src/enrollment.rs
@@ -192,7 +192,6 @@ pub fn opt_out(db: &Database, experiment_slug: &str) -> Result<()> {
 mod tests {
     use super::*;
     use crate::persistence::{Database, StoreId};
-    use crate::AvailableRandomizationUnits;
     use serde_json::json;
     use tempdir::TempDir;
 
@@ -260,9 +259,7 @@ mod tests {
         let db = Database::new(&tmp_dir)?;
         let exp = &get_test_experiments()[0];
         let nimbus_id = Uuid::new_v4();
-        let aru = AvailableRandomizationUnits {
-            client_id: "guid".to_string(),
-        };
+        let aru = Default::default();
         assert_eq!(get_enrollments(&db)?.len(), 0);
         db.put(
             StoreId::Experiments,
@@ -314,9 +311,7 @@ mod tests {
         let tmp_dir = TempDir::new("test_updates")?;
         let db = Database::new(&tmp_dir)?;
         let nimbus_id = Uuid::new_v4();
-        let aru = AvailableRandomizationUnits {
-            client_id: "guid".to_string(),
-        };
+        let aru = Default::default();
         assert_eq!(get_enrollments(&db)?.len(), 0);
         let exps = get_test_experiments();
         for exp in exps {

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -228,15 +228,30 @@ impl Default for RandomizationUnit {
     }
 }
 
+#[derive(Default)]
 pub struct AvailableRandomizationUnits {
-    pub client_id: String,
+    pub client_id: Option<String>,
+    dummy: u8, // See comments in nimbus.idl for why this hacky item exists.
 }
 
 impl AvailableRandomizationUnits {
-    pub fn get_value<'a>(&'a self, nimbus_id: &'a str, wanted: &'a RandomizationUnit) -> &'a str {
+    // Use ::with_client_id when you want to specify one, or use
+    // Default::default if you don't!
+    pub fn with_client_id(client_id: &str) -> Self {
+        Self {
+            client_id: Some(client_id.to_string()),
+            dummy: 0,
+        }
+    }
+
+    pub fn get_value<'a>(
+        &'a self,
+        nimbus_id: &'a str,
+        wanted: &'a RandomizationUnit,
+    ) -> Option<&'a str> {
         match wanted {
-            RandomizationUnit::NimbusId => nimbus_id,
-            RandomizationUnit::ClientId => &self.client_id,
+            RandomizationUnit::NimbusId => Some(nimbus_id),
+            RandomizationUnit::ClientId => self.client_id.as_deref(),
         }
     }
 }

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -27,7 +27,11 @@ dictionary RemoteSettingsConfig {
 };
 
 dictionary AvailableRandomizationUnits {
-    string client_id;
+    string? client_id;
+    // work around uniffi-rs #331 by including a non-optional value. We'll
+    // try and hide this in the bindings used by clients and eventually remove
+    // it entirely.
+    u8 dummy;
 };
 
 [Error]

--- a/nimbus/tests/test_fs_client.rs
+++ b/nimbus/tests/test_fs_client.rs
@@ -4,7 +4,7 @@
 
 // Simple tests for our file-system client
 
-use nimbus::{error::Result, AvailableRandomizationUnits, NimbusClient, RemoteSettingsConfig};
+use nimbus::{error::Result, NimbusClient, RemoteSettingsConfig};
 use std::path::PathBuf;
 use tempdir::TempDir;
 use url::Url;
@@ -26,9 +26,7 @@ fn test_simple() -> Result<()> {
 
     let tmp_dir = TempDir::new("test_fs_client-test_simple")?;
 
-    let aru = AvailableRandomizationUnits {
-        client_id: "guid".to_string(),
-    };
+    let aru = Default::default();
     let client = NimbusClient::new(Default::default(), tmp_dir.path(), config, aru)?;
 
     let experiments = client.get_all_experiments()?;


### PR DESCRIPTION
How does this look? I don't think there's anything we can do here to avoid JS code dealing with the dummy field, although I think @travis's a-c PR can hide that from Android app consumers.

(I'm also assuming an `i8` works around the problem and is lighter-weight than a string - @dmose is it your understanding that should work OK?)