### PR TITLE
Bump uniffi dependency to 0.4.0 to fix license goofiness for m-c

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,9 +10,6 @@ jobs:
           name: Version information
           command: rustc --version; cargo --version; rustup --version
       - run:
-          name: Install uniffi
-          command: cargo install --version 0.3.0 uniffi_bindgen
-      - run:
           name: Calculate dependencies
           command: cd nimbus && cargo generate-lockfile
       - restore_cache:

--- a/nimbus/Cargo.lock
+++ b/nimbus/Cargo.lock
@@ -1515,9 +1515,9 @@ checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "uniffi"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421f78982027ce32235052fba9d147c7094596a6404b71cb761ca653d53786b2"
+checksum = "61c4ab58b81243770e57108ea885c938ea81c6fcb89d46a96f6a33842cf6f67a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1530,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc7613a3f7a0c18d64993d1d6e5d4e4ad9b7d6ba9fa9b0b3d2847fc00f1e1e1"
+checksum = "0923223a674334c32c4b45d054339426b04826ec1e751ebcc99b61a9fcee0bc8"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/nimbus/Cargo.lock
+++ b/nimbus/Cargo.lock
@@ -31,6 +31,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
+name = "askama"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e7ebd44d0047fd48206c83c5cd3214acc7b9d87f001da170145c47ef7d12"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+ "askama_shared",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d7169690c4f56343dcd821ab834972a22570a2662a19a84fd7775d5e1c3881"
+dependencies = [
+ "askama_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c108c1a94380c89d2215d0ac54ce09796823cca0fd91b299cfff3b33e346fb"
+
+[[package]]
+name = "askama_shared"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62fc272363345c8cdc030e4c259d9d028237f8b057dc9bb327772a257bde6bb5"
+dependencies = [
+ "askama_escape",
+ "humansize",
+ "nom",
+ "num-traits",
+ "percent-encoding",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "toml",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +458,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00d63df3d41950fb462ed38308eea019113ad1508da725bbedcd0fa5a85ef5f7"
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +513,12 @@ name = "httpdate"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+
+[[package]]
+name = "humansize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e"
 
 [[package]]
 name = "humantime"
@@ -781,6 +843,16 @@ dependencies = [
  "uuid",
  "viaduct",
  "viaduct-reqwest",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "memchr",
+ "version_check",
 ]
 
 [[package]]
@@ -1437,6 +1509,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1502,6 +1583,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1616,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "uniffi_bindgen"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a259359cdd5009ebfd6cb25d4b8de60709c67efa6ba73d6f1356de7c4712d4f"
+dependencies = [
+ "anyhow",
+ "askama",
+ "cargo_metadata",
+ "clap",
+ "heck",
+ "serde",
+ "toml",
+ "weedle",
+]
+
+[[package]]
 name = "uniffi_build"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,6 +1639,7 @@ checksum = "0923223a674334c32c4b45d054339426b04826ec1e751ebcc99b61a9fcee0bc8"
 dependencies = [
  "anyhow",
  "cargo_metadata",
+ "uniffi_bindgen",
 ]
 
 [[package]]
@@ -1697,6 +1801,15 @@ checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "weedle"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7d4f9feb723a800d8f7b74edc9fa44ff35cb0b2ec64886714362f423427f37"
+dependencies = [
+ "nom",
 ]
 
 [[package]]

--- a/nimbus/Cargo.toml
+++ b/nimbus/Cargo.toml
@@ -32,7 +32,7 @@ once_cell = "1"
 uniffi = "0.4"
 
 [build-dependencies]
-uniffi_build = "0.4"
+uniffi_build = { version = "0.4", features = [ "builtin-bindgen" ] }
 
 [dev-dependencies]
 viaduct-reqwest = { git = "https://github.com/mozilla/application-services",  rev = "2478bcf2b48d1867b01e8b7df4f86a69d564d49a"}

--- a/nimbus/Cargo.toml
+++ b/nimbus/Cargo.toml
@@ -29,10 +29,10 @@ uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"
 once_cell = "1"
-uniffi = "0.3"
+uniffi = "0.4"
 
 [build-dependencies]
-uniffi_build = "0.3"
+uniffi_build = "0.4"
 
 [dev-dependencies]
 viaduct-reqwest = { git = "https://github.com/mozilla/application-services",  rev = "2478bcf2b48d1867b01e8b7df4f86a69d564d49a"}


### PR DESCRIPTION
Obviously, CI won't pass and I won't try to land this until after the uniffi PR lands.  