### PR TITLE
Add schema version validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased changes
 
-Unreleased changes go here.
+## General
+
+Addition of schema version to the schema, and validation of supported versions by the SDK.
 
 # 0.5.1 (_2020-11-10)
 

--- a/nimbus/src/enrollment.rs
+++ b/nimbus/src/enrollment.rs
@@ -4,8 +4,7 @@
 use crate::error::Result;
 use crate::evaluator::evaluate_enrollment;
 use crate::persistence::{Database, StoreId, Writer};
-use crate::AvailableRandomizationUnits;
-use crate::{AppContext, EnrolledExperiment, Experiment};
+use crate::{AppContext, AvailableRandomizationUnits, EnrolledExperiment, Experiment};
 
 use ::uuid::Uuid;
 use serde_derive::*;
@@ -260,6 +259,7 @@ mod tests {
     fn get_test_experiments() -> Vec<serde_json::Value> {
         vec![
             json!({
+                "schemaVersion": "1.0.0",
                 "slug": "secure-gold",
                 "endDate": null,
                 "branches":[
@@ -286,6 +286,7 @@ mod tests {
                 "last_modified":1_602_197_324_372i64
             }),
             json!({
+                "schemaVersion": "1.0.0",
                 "slug": "secure-silver",
                 "endDate": null,
                 "branches":[

--- a/nimbus/src/error.rs
+++ b/nimbus/src/error.rs
@@ -1,6 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * */
 
 //! Not complete yet
 //! This is where the error definitions can go

--- a/nimbus/src/evaluator.rs
+++ b/nimbus/src/evaluator.rs
@@ -1,13 +1,7 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-//! This might be where the bucketing logic can go
-//! It would be different from current experimentation tools
-//! There is a namespacing concept to allow users to be in multiple
-//! unrelated experiments at the same time.
-
-//! TODO: Implement the bucketing logic from the nimbus project
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 
 use crate::enrollment::{EnrolledReason, EnrollmentStatus, ExperimentEnrollment};
 use crate::{
@@ -51,7 +45,7 @@ pub fn evaluate_enrollment(
     app_context: &AppContext,
     exp: &Experiment,
 ) -> Result<ExperimentEnrollment> {
-    // get targeting out of the way first - "if let chains" are experimental,
+    // Get targeting out of the way first - "if let chains" are experimental,
     // otherwise we could improve this.
     if let Some(expr) = &exp.targeting {
         if let Some(status) = targeting(expr, app_context) {
@@ -301,6 +295,7 @@ mod tests {
     #[test]
     fn test_get_enrollment() {
         let experiment1 = Experiment {
+            schema_version: "1.0.0".to_string(),
             slug: "TEST_EXP1".to_string(),
             is_enrollment_paused: false,
             bucket_config: BucketConfig {

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -204,9 +204,16 @@ pub struct EnrolledExperiment {
     pub branch_slug: String,
 }
 
+/// This is the currently supported major schema version.
+pub const SCHEMA_VERSION: i32 = 1;
+// XXX: In the future it would be nice if this lived in its own versioned crate so that
+// the schema could be decoupled from the sdk so that it can be iterated on while the
+// sdk depends on a particular version of the schema through the cargo.toml.
+
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Experiment {
+    pub schema_version: String,
     pub slug: String,
     pub application: String,
     pub user_facing_name: String,

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -205,7 +205,7 @@ pub struct EnrolledExperiment {
 }
 
 /// This is the currently supported major schema version.
-pub const SCHEMA_VERSION: i32 = 1;
+pub const SCHEMA_VERSION: u32 = 1;
 // XXX: In the future it would be nice if this lived in its own versioned crate so that
 // the schema could be decoupled from the sdk so that it can be iterated on while the
 // sdk depends on a particular version of the schema through the cargo.toml.

--- a/nimbus/tests/experiments/invalid-experiment-missing-slug.json
+++ b/nimbus/tests/experiments/invalid-experiment-missing-slug.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": "1.0.0",
   "endDate": null,
   "branches": [
     {

--- a/nimbus/tests/experiments/secure-gold.json
+++ b/nimbus/tests/experiments/secure-gold.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": "1.0.0",
   "slug": "secure-gold",
   "endDate": null,
   "branches": [


### PR DESCRIPTION
This is still a WIP for adding schema version validation.

Design requirements:
* SDK maintains awareness of the supported schema version
* Check the "schemaVersion" field before doing any other processing or validation of experiment config.
* If the major version number is higher than the version supported by the SDK, ignore the experiment (in future we would probably emit some diagnostic telemetry here)
* Document how this is meant to work for clients and their responsibility in testing and updating the nimbus-sdk.

Open question:
* Is backwards compatibility for all previous versions assumed? If not - what are the limits?