### PR TITLE
Add global opt in/out

### DIFF
--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -28,6 +28,8 @@ use uuid::Uuid;
 
 const DEFAULT_TOTAL_BUCKETS: u32 = 10000;
 const DB_KEY_NIMBUS_ID: &str = "nimbus-id";
+const DB_KEY_GLOBAL_USER_PARTICIPATION: &str = "user-opt-in";
+const DEFAULT_GLOBAL_USER_PARTICIPATION: bool = true;
 
 /// Nimbus is the main struct representing the experiments state
 /// It should hold all the information needed to communicate a specific user's
@@ -80,7 +82,23 @@ impl NimbusClient {
             .map(|e| e.branch_slug.clone()))
     }
 
+    pub fn get_global_user_participation(&self) -> Result<Option<bool>> {
+        self.db()?.get(StoreId::Meta, DB_KEY_GLOBAL_USER_PARTICIPATION)
+    }
+
+    pub fn set_global_user_participation(&self, flag: bool) -> Result<()> {
+        self.db()?.put(StoreId::Meta, DB_KEY_GLOBAL_USER_PARTICIPATION, &flag)
+    }
+
+    fn is_enabled(&self) -> Result<bool> {
+        let user_choice = self.get_global_user_participation()?;
+        Ok(user_choice.unwrap_or(DEFAULT_GLOBAL_USER_PARTICIPATION))
+    }
+
     pub fn get_active_experiments(&self) -> Result<Vec<EnrolledExperiment>> {
+        if !self.is_enabled()? {
+            return Ok(Default::default());
+        }
         self.maybe_initial_experiment_fetch()?;
         get_enrollments(self.db()?)
     }

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -17,7 +17,8 @@ pub use evaluator::evaluate_enrollment;
 use client::{create_client, SettingsClient};
 pub use config::RemoteSettingsConfig;
 use enrollment::{
-    get_enrollments, opt_in_with_branch, opt_out, reset_enrollment, update_enrollments,
+    get_enrollments, get_global_user_participation, opt_in_with_branch, opt_out, reset_enrollment,
+    set_global_user_participation, update_enrollments,
 };
 pub use matcher::AppContext;
 use once_cell::sync::OnceCell;
@@ -28,8 +29,6 @@ use uuid::Uuid;
 
 const DEFAULT_TOTAL_BUCKETS: u32 = 10000;
 const DB_KEY_NIMBUS_ID: &str = "nimbus-id";
-const DB_KEY_GLOBAL_USER_PARTICIPATION: &str = "user-opt-in";
-const DEFAULT_GLOBAL_USER_PARTICIPATION: bool = true;
 
 /// Nimbus is the main struct representing the experiments state
 /// It should hold all the information needed to communicate a specific user's
@@ -82,23 +81,22 @@ impl NimbusClient {
             .map(|e| e.branch_slug.clone()))
     }
 
-    pub fn get_global_user_participation(&self) -> Result<Option<bool>> {
-        self.db()?.get(StoreId::Meta, DB_KEY_GLOBAL_USER_PARTICIPATION)
+    pub fn get_global_user_participation(&self) -> Result<bool> {
+        get_global_user_participation(self.db()?)
     }
 
     pub fn set_global_user_participation(&self, flag: bool) -> Result<()> {
-        self.db()?.put(StoreId::Meta, DB_KEY_GLOBAL_USER_PARTICIPATION, &flag)
-    }
-
-    fn is_enabled(&self) -> Result<bool> {
-        let user_choice = self.get_global_user_participation()?;
-        Ok(user_choice.unwrap_or(DEFAULT_GLOBAL_USER_PARTICIPATION))
+        set_global_user_participation(self.db()?, flag)?;
+        // Now update all enrollments based on this new opt in/out setting.
+        update_enrollments(
+            self.db()?,
+            &self.nimbus_id()?,
+            &self.available_randomization_units,
+            &self.app_context,
+        )
     }
 
     pub fn get_active_experiments(&self) -> Result<Vec<EnrolledExperiment>> {
-        if !self.is_enabled()? {
-            return Ok(Default::default());
-        }
         self.maybe_initial_experiment_fetch()?;
         get_enrollments(self.db()?)
     }

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -63,6 +63,17 @@ interface NimbusClient {
     [Throws=Error]
     sequence<EnrolledExperiment> get_active_experiments();
 
+    // Getter and setter for user's participation in all experiments.
+    // Possible values are:
+    // * `true`: user has opted in.
+    // * `false`: user has opted out
+    // * null: user has not made a choice.
+    [Throws=Error]
+    boolean? get_global_user_participation();
+
+    [Throws=Error]
+    void set_global_user_participation(boolean opt_in);
+
     // Updates the list of experiments from the server. After calling this, the
     // list of active experiments might change (there might be new experiments,
     // or old experiments might have expired)

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -65,11 +65,10 @@ interface NimbusClient {
 
     // Getter and setter for user's participation in all experiments.
     // Possible values are:
-    // * `true`: user has opted in.
-    // * `false`: user has opted out
-    // * null: user has not made a choice.
+    // * `true`: the user will not enroll in new experiments, and opt out of all exisitng ones.
+    // * `false`: experiments proceed as usual.
     [Throws=Error]
-    boolean? get_global_user_participation();
+    boolean get_global_user_participation();
 
     [Throws=Error]
     void set_global_user_participation(boolean opt_in);


### PR DESCRIPTION
This PR adds a global opt in or opt out for all experiments for the user to express a preference about participating in any experiments.

If the user has opted out, `get_active_experiments()` returns an empty list of experiments.

The naming is a bit clunky, because:

1. This flag codes for "don't enroll  the user in new experiments" as well as "opt out of already enrolled experiments".
2. I'd prefer it to be a positive choice (`!is_enabled` is better than `is_disabled`).

The name `globalUserParticipation` was first proposed in the [Nimbus Android Component API doc][1]

This corresponds to @tdsmith  [Unpacking opting out][3] compatible with [Intent to treat analysis][4].

 * If the user is already enrolled in an experiment, then the experiment is given an enrollment status of `OptedOut`.
 * When new experiments are encountered, no enrollment status is given.

Linked to [Nimbus SDK-36][2].

[1]: https://docs.google.com/document/d/1kchihPal0__A4VOAiPJarNuZXns5KhOHHfIeIzT6zfU/edit#
[2]: https://jira.mozilla.com/projects/SDK/issues/SDK-36
[3]: https://docs.google.com/document/d/18Vdn4zZX2D1u9AqzHRY0lUSUbpBdouqWtVp3Bu8vYQA/edit#
[4]: https://en.wikipedia.org/wiki/Intention-to-treat_analysis
