### PR TITLE
Use a signed byte for the dummy value in AvailableRandomizationUnits.

### DIFF
--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -231,7 +231,7 @@ impl Default for RandomizationUnit {
 #[derive(Default)]
 pub struct AvailableRandomizationUnits {
     pub client_id: Option<String>,
-    dummy: u8, // See comments in nimbus.idl for why this hacky item exists.
+    dummy: i8, // See comments in nimbus.idl for why this hacky item exists.
 }
 
 impl AvailableRandomizationUnits {

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -31,7 +31,7 @@ dictionary AvailableRandomizationUnits {
     // work around uniffi-rs #331 by including a non-optional value. We'll
     // try and hide this in the bindings used by clients and eventually remove
     // it entirely.
-    u8 dummy;
+    i8 dummy;
 };
 
 [Error]


### PR DESCRIPTION
Unsigned types are currently experimental in Kotlin, and can only be
used by consumers if they explicitly opt in. Let's not put this opt-in
requirement on all consumers of this SDK if we can avoid it.