### PR TITLE
Ignore spurious dead-code warnings about `is_enrolled`.

### DIFF
--- a/nimbus/src/enrollment.rs
+++ b/nimbus/src/enrollment.rs
@@ -49,6 +49,8 @@ pub enum EnrollmentStatus {
 }
 
 impl EnrollmentStatus {
+    // This is used in examples, but not in the main dylib.
+    #[allow(dead_code)]
     pub fn is_enrolled(&self) -> bool {
         matches!(self, EnrollmentStatus::Enrolled { .. })
     }


### PR DESCRIPTION
This isn't used in the main library but *is* used by examples, so let's silence the warning. (It's causing compile failures for the appservices megazord in taskcluster, where warnings seem to be treated as errors)