### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 Unreleased changes go here.
 
-# 1.0.0 (_2020-10-27_)
+# 0.4.0 (_2020-11-06)
+
+## General
+
+### What's Fixed
+
+- Removed use of unsigned types from the Kotlin API, since these
+  are experimental and require opt-in from consuming apps.
+- Fixed various warnings when compiling the Rust code.
+
+
+# 0.3.0 (_2020-10-27_)
 
 ## General
 

--- a/android/.buildconfig.yaml
+++ b/android/.buildconfig.yaml
@@ -1,4 +1,4 @@
-libraryVersion: 0.3.0
+libraryVersion: 0.4.0
 groupId: org.mozilla.experiments
 artifactId: nimbus
 description: A uniffi generated android bindings for the Nimbus SDK

--- a/nimbus/Cargo.toml
+++ b/nimbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nimbus-sdk"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The Glean Team <glean-team@mozilla.com>", "The Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 description = "A rapid experiment library"


### PR DESCRIPTION
Technically a breaking change because of the `u8` -> `i8` thing...