### PR TITLE
Make "bucket" preceed "collection" in `RemoteSettingsConfig`.

### DIFF
--- a/nimbus/examples/README.md
+++ b/nimbus/examples/README.md
@@ -20,8 +20,8 @@ You can set a config file using the `-c` option, which can include the following
 {
     "context": {..},// App context elements
     "server_url": "...", // A remote settings url
-    "collection_name": "...", // Name of a collection in the remote server (Defaults to `messaging-experiment`)
     "bucket_name": "..." // Name of the bucket in the remote server (Defaults to `main`)
+    "collection_name": "...", // Name of a collection in the remote server (Defaults to `messaging-experiment`)
     "uuid": ".." // A custom uuid to use
 }
 ```

--- a/nimbus/examples/experiment.rs
+++ b/nimbus/examples/experiment.rs
@@ -201,8 +201,8 @@ fn main() -> Result<()> {
     // initiate the optional config
     let config = RemoteSettingsConfig {
         server_url: server_url.to_string(),
-        collection_name: collection_name.to_string(),
         bucket_name: bucket_name.to_string(),
+        collection_name: collection_name.to_string(),
     };
 
     let aru = AvailableRandomizationUnits::with_client_id(&client_id);

--- a/nimbus/src/client/http_client.rs
+++ b/nimbus/src/client/http_client.rs
@@ -32,8 +32,8 @@ impl Client {
         let base_url = Url::parse(&config.server_url)?;
         Ok(Self {
             base_url,
-            collection_name: config.collection_name,
             bucket_name: config.bucket_name,
+            collection_name: config.collection_name,
         })
     }
 
@@ -137,8 +137,8 @@ mod tests {
         .create();
         let config = RemoteSettingsConfig {
             server_url: mockito::server_url(),
-            collection_name: "messaging-experiments".to_string(),
             bucket_name: "main".to_string(),
+            collection_name: "messaging-experiments".to_string(),
         };
         let http_client = Client::new(config).unwrap();
         let resp = http_client.get_experiments().unwrap();

--- a/nimbus/src/config.rs
+++ b/nimbus/src/config.rs
@@ -15,6 +15,6 @@
 #[derive(Debug, Clone)]
 pub struct RemoteSettingsConfig {
     pub server_url: String,
-    pub collection_name: String,
     pub bucket_name: String,
+    pub collection_name: String,
 }

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -22,8 +22,8 @@ dictionary EnrolledExperiment {
 
 dictionary RemoteSettingsConfig {
     string server_url;
-    string collection_name;
     string bucket_name;
+    string collection_name;
 };
 
 dictionary AvailableRandomizationUnits {

--- a/nimbus/tests/test_fs_client.rs
+++ b/nimbus/tests/test_fs_client.rs
@@ -20,8 +20,8 @@ fn test_simple() -> Result<()> {
 
     let config = RemoteSettingsConfig {
         server_url: url.as_str().to_string(),
-        collection_name: "doesn't matter".to_string(),
         bucket_name: "doesn't matter".to_string(),
+        collection_name: "doesn't matter".to_string(),
     };
 
     let tmp_dir = TempDir::new("test_fs_client-test_simple")?;


### PR DESCRIPTION
The Remote Settings data model consists of buckets that contain
collections that contain records. Currently the `RemoteSettingsConfig`
data class orders its fields as server url, then collection, then
bucket (like some sort of reverse American-format date).

To help readers build an accurate mental model, this commit changes
the field order so they appear in order of increasing specificity
just like they would in the underlying URL: root server URL, then
bucket, then collection (like a nice ISO-8601-format date).