### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Unreleased changes go here.
 
+# 0.5.1 (_2020-11-10)
+
+- Fix the version number in `Cargo.lock`.
 
 # 0.5.0 (_2020-11-10)
 

--- a/android/.buildconfig.yaml
+++ b/android/.buildconfig.yaml
@@ -1,4 +1,4 @@
-libraryVersion: 0.5.0
+libraryVersion: 0.5.1
 groupId: org.mozilla.experiments
 artifactId: nimbus
 description: A uniffi generated android bindings for the Nimbus SDK

--- a/nimbus/Cargo.lock
+++ b/nimbus/Cargo.lock
@@ -824,7 +824,7 @@ dependencies = [
 
 [[package]]
 name = "nimbus-sdk"
-version = "0.4.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/nimbus/Cargo.toml
+++ b/nimbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nimbus-sdk"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The Glean Team <glean-team@mozilla.com>", "The Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 description = "A rapid experiment library"


### PR DESCRIPTION
This time with updated `Cargo.lock`, which I forgot to do over in https://github.com/mozilla/nimbus-sdk/pull/63