### PR TITLE
Make RemoteSettingsConfig nullable in NimbusClient constructor

### DIFF
--- a/nimbus/examples/experiment.rs
+++ b/nimbus/examples/experiment.rs
@@ -208,7 +208,7 @@ fn main() -> Result<()> {
     let aru = AvailableRandomizationUnits::with_client_id(&client_id);
 
     // Here we initialize our main `NimbusClient` struct
-    let nimbus_client = NimbusClient::new(context, "", config, aru)?;
+    let nimbus_client = NimbusClient::new(context, "", Some(config), aru)?;
 
     // We match against the subcommands
     match matches.subcommand() {

--- a/nimbus/src/client/mod.rs
+++ b/nimbus/src/client/mod.rs
@@ -4,30 +4,39 @@
 
 mod fs_client;
 mod http_client;
+mod null_client;
 use crate::error::{Error, Result};
 use crate::Experiment;
 use crate::RemoteSettingsConfig;
 use fs_client::FileSystemClient;
 use http_client::Client;
+use null_client::NullClient;
 use url::Url;
 
 pub(crate) fn create_client(
-    config: RemoteSettingsConfig,
+    config: Option<RemoteSettingsConfig>,
 ) -> Result<Box<dyn SettingsClient + Send>> {
-    // XXX - double-parsing the URL here if it's not a file:// URL - ideally
-    // config would already be holding a Url and we wouldn't parse here at all.
-    let url = Url::parse(&config.server_url)?;
-    Ok(if url.scheme() == "file" {
-        // Everything in `config` other than the url/path is ignored for the
-        // file-system - we could insist on a sub-directory, but that doesn't
-        // seem valuable for the use-cases we care about here.
-        let path = match url.to_file_path() {
-            Ok(path) => path,
-            _ => return Err(Error::InvalidPath(config.server_url)),
-        };
-        Box::new(FileSystemClient::new(path)?)
-    } else {
-        Box::new(Client::new(config)?)
+    Ok(match config {
+        Some(config) => {
+            // XXX - double-parsing the URL here if it's not a file:// URL - ideally
+            // config would already be holding a Url and we wouldn't parse here at all.
+            let url = Url::parse(&config.server_url)?;
+            if url.scheme() == "file" {
+                // Everything in `config` other than the url/path is ignored for the
+                // file-system - we could insist on a sub-directory, but that doesn't
+                // seem valuable for the use-cases we care about here.
+                let path = match url.to_file_path() {
+                    Ok(path) => path,
+                    _ => return Err(Error::InvalidPath(config.server_url)),
+                };
+                Box::new(FileSystemClient::new(path)?)
+            } else {
+                Box::new(Client::new(config)?)
+            }
+        }
+        // If no server is provided, then we still want Nimbus to work, but serving
+        // an empty list of experiments.
+        None => Box::new(NullClient::new()),
     })
 }
 

--- a/nimbus/src/client/null_client.rs
+++ b/nimbus/src/client/null_client.rs
@@ -1,0 +1,44 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+use crate::error::Result;
+use crate::{Experiment, SettingsClient};
+
+/// This is a client for use when no server is provided.
+/// Its primary use is for non-Mozilla forks of apps that are not using their
+/// own server infrastructure.
+pub struct NullClient;
+
+impl NullClient {
+    pub fn new() -> Self {
+        NullClient
+    }
+}
+
+impl SettingsClient for NullClient {
+    fn get_experiments_metadata(&self) -> Result<String> {
+        unimplemented!();
+    }
+    fn get_experiments(&self) -> Result<Vec<Experiment>> {
+        Ok(vec![])
+    }
+}
+
+#[cfg(feature = "rkv-safe-mode")]
+#[test]
+fn test_null_client() -> Result<()> {
+    use crate::NimbusClient;
+    use tempdir::TempDir;
+
+    let _ = env_logger::try_init();
+
+    let tmp_dir = TempDir::new("test_null_client-test_null")?;
+
+    let aru = Default::default();
+    let client = NimbusClient::new(Default::default(), tmp_dir.path(), None, aru)?;
+
+    let experiments = client.get_all_experiments()?;
+    assert_eq!(experiments.len(), 0);
+    Ok(())
+}

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -47,7 +47,7 @@ impl NimbusClient {
     pub fn new<P: Into<PathBuf>>(
         app_context: AppContext,
         db_path: P,
-        config: RemoteSettingsConfig,
+        config: Option<RemoteSettingsConfig>,
         available_randomization_units: AvailableRandomizationUnits,
     ) -> Result<Self> {
         let settings_client = create_client(config)?;

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -48,7 +48,7 @@ interface NimbusClient {
     constructor(
         AppContext app_ctx,
         string dbpath,
-        RemoteSettingsConfig remote_settings_config,
+        RemoteSettingsConfig? remote_settings_config,
         AvailableRandomizationUnits available_randomization_units
     );
 

--- a/nimbus/tests/test_fs_client.rs
+++ b/nimbus/tests/test_fs_client.rs
@@ -33,7 +33,7 @@ fn test_simple() -> Result<()> {
     let tmp_dir = TempDir::new("test_fs_client-test_simple")?;
 
     let aru = Default::default();
-    let client = NimbusClient::new(Default::default(), tmp_dir.path(), config, aru)?;
+    let client = NimbusClient::new(Default::default(), tmp_dir.path(), Some(config), aru)?;
 
     let experiments = client.get_all_experiments()?;
     assert_eq!(experiments.len(), 1);


### PR DESCRIPTION
Fixes [SDK-97][1].

It makes the remote settings config an `Option` and configures the SDK to use a `NullClient` which serves no experiments.

[1]: https://jira.mozilla.com/browse/SDK-97