### PR TITLE
Don't implicitly update experiments on first use.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Addition of schema version to the schema, and validation of supported versions by the SDK.
 
+Removed implicit fetch of experiments on first use of the database. Consumers now must
+call update_experiments explicitly in order to fetch experiments from the Remote Settings
+server.
+
 # 0.5.1 (_2020-11-10)
 
 - Fix the version number in `Cargo.lock`.

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -60,19 +60,6 @@ impl NimbusClient {
         })
     }
 
-    // This is a little suspect but it's not clear what the right thing is.
-    // Maybe it's OK we initially start with no experiments and just need to
-    // wait for the app to schedule a regular `update_experiments()` call?
-    // But for now, if we have no experiments we assume we have never
-    // successfully hit our server, so should do that now.
-    fn maybe_initial_experiment_fetch(&self) -> Result<()> {
-        if !self.db()?.has_any(StoreId::Experiments)? {
-            log::info!("No experiments in our database - fetching them");
-            self.update_experiments()?;
-        }
-        Ok(())
-    }
-
     pub fn get_experiment_branch(&self, slug: String) -> Result<Option<String>> {
         Ok(self
             .get_active_experiments()?
@@ -107,12 +94,10 @@ impl NimbusClient {
     }
 
     pub fn get_active_experiments(&self) -> Result<Vec<EnrolledExperiment>> {
-        self.maybe_initial_experiment_fetch()?;
         get_enrollments(self.db()?)
     }
 
     pub fn get_all_experiments(&self) -> Result<Vec<Experiment>> {
-        self.maybe_initial_experiment_fetch()?;
         self.db()?.collect_all(StoreId::Experiments)
     }
 

--- a/nimbus/src/persistence.rs
+++ b/nimbus/src/persistence.rs
@@ -125,12 +125,6 @@ impl SingleStore {
         }
         Ok(result)
     }
-
-    #[allow(dead_code)]
-    pub fn has_any(&self, writer: &Writer) -> Result<bool> {
-        let mut iter = self.store.iter_start(writer)?;
-        Ok(iter.next().is_some())
-    }
 }
 
 /// Database used to access persisted data
@@ -230,12 +224,6 @@ impl Database {
             }
         }
         Ok(result)
-    }
-
-    pub fn has_any(&self, store_id: StoreId) -> Result<bool> {
-        let reader = self.rkv.read()?;
-        let mut iter = self.get_store(store_id).store.iter_start(&reader)?;
-        Ok(iter.next().is_some())
     }
 }
 

--- a/nimbus/tests/test_fs_client.rs
+++ b/nimbus/tests/test_fs_client.rs
@@ -34,6 +34,7 @@ fn test_simple() -> Result<()> {
 
     let aru = Default::default();
     let client = NimbusClient::new(Default::default(), tmp_dir.path(), Some(config), aru)?;
+    client.update_experiments()?;
 
     let experiments = client.get_all_experiments()?;
     assert_eq!(experiments.len(), 1);


### PR DESCRIPTION
(Based on the behaviour @eoger and @travis79 noted in our meeting earlier today).

Previously, we would implicity call `update_experiments` when trying
to list the experiments in an empty database. We would not update
if the database contained at least one experiment, no matter how stale.

In practice this seems to be a bit of a footgun, because it looks
to consumers like we'll automatically update definitions when
initialising the client, but this only works once.

Instead, let's require consumers to make an explicit call to
`update_experiments` whenever they want to update the experiments.

This will require us to do https://jira.mozilla.com/browse/SDK-121 on
the android-components side.