### PR TITLE
Add normandy_id to available randomization units

### DIFF
--- a/nimbus/src/evaluator.rs
+++ b/nimbus/src/evaluator.rs
@@ -376,7 +376,8 @@ mod tests {
 
         // Fits because of the normandy_id.
         let id = uuid::Uuid::parse_str("9d275791-3f31-4549-b30c-e32c750e4787").unwrap();
-        let available_randomization_units = AvailableRandomizationUnits::with_normandy_id(&id.to_string());
+        let available_randomization_units =
+            AvailableRandomizationUnits::with_normandy_id(&id.to_string());
         let enrollment = evaluate_enrollment(
             &id,
             &available_randomization_units,

--- a/nimbus/src/evaluator.rs
+++ b/nimbus/src/evaluator.rs
@@ -323,6 +323,17 @@ mod tests {
             total: 10000,
         };
         experiment2.slug = "TEST_EXP2".to_string();
+        let mut experiment3 = experiment1.clone();
+        experiment3.bucket_config = BucketConfig {
+            randomization_unit: RandomizationUnit::NormandyId,
+            namespace:
+                "bug-1637316-message-aboutwelcome-pull-factor-reinforcement-76-rel-release-76-77"
+                    .to_string(),
+            start: 9000,
+            count: 1000,
+            total: 10000,
+        };
+        experiment3.slug = "TEST_EXP3".to_string();
         // We will not match EXP_2 because we don't have the necessary randomization unit.
         let available_randomization_units = Default::default();
         // 299eed1e-be6d-457d-9e53-da7b1a03f10d uuid fits in start: 0, count: 2000, total: 10000 with the example namespace, to the treatment-variation-b branch
@@ -357,6 +368,20 @@ mod tests {
             &available_randomization_units,
             &Default::default(),
             &experiment2,
+        )
+        .unwrap();
+        assert!(
+            matches!(enrollment.status, EnrollmentStatus::Enrolled { reason: EnrolledReason::Qualified, .. })
+        );
+
+        // Fits because of the normandy_id.
+        let id = uuid::Uuid::parse_str("9d275791-3f31-4549-b30c-e32c750e4787").unwrap();
+        let available_randomization_units = AvailableRandomizationUnits::with_normandy_id(&id.to_string());
+        let enrollment = evaluate_enrollment(
+            &id,
+            &available_randomization_units,
+            &Default::default(),
+            &experiment3,
         )
         .unwrap();
         assert!(

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -254,6 +254,7 @@ pub struct BucketConfig {
 pub enum RandomizationUnit {
     NimbusId,
     ClientId,
+    NormandyId,
 }
 
 impl Default for RandomizationUnit {
@@ -265,6 +266,7 @@ impl Default for RandomizationUnit {
 #[derive(Default)]
 pub struct AvailableRandomizationUnits {
     pub client_id: Option<String>,
+    pub normandy_id: Option<String>,
     dummy: i8, // See comments in nimbus.idl for why this hacky item exists.
 }
 
@@ -274,6 +276,15 @@ impl AvailableRandomizationUnits {
     pub fn with_client_id(client_id: &str) -> Self {
         Self {
             client_id: Some(client_id.to_string()),
+            normandy_id: None,
+            dummy: 0,
+        }
+    }
+
+    pub fn with_normandy_id(normandy_id: &str) -> Self {
+        Self {
+            client_id: None,
+            normandy_id: Some(normandy_id.to_string()),
             dummy: 0,
         }
     }
@@ -286,6 +297,7 @@ impl AvailableRandomizationUnits {
         match wanted {
             RandomizationUnit::NimbusId => Some(nimbus_id),
             RandomizationUnit::ClientId => self.client_id.as_deref(),
+            RandomizationUnit::NormandyId => self.normandy_id.as_deref(),
         }
     }
 }

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -28,6 +28,7 @@ dictionary RemoteSettingsConfig {
 
 dictionary AvailableRandomizationUnits {
     string? client_id;
+    string? normandy_id;
     // work around uniffi-rs #331 by including a non-optional value. We'll
     // try and hide this in the bindings used by clients and eventually remove
     // it entirely.


### PR DESCRIPTION
Currently Firefox only accepts `normandy_id` as randomization unit and drops any other recipe as incompatible.