### PR TITLE
Implement Backoff/Retry-After support

### DIFF
--- a/nimbus/examples/experiment.rs
+++ b/nimbus/examples/experiment.rs
@@ -196,7 +196,7 @@ fn main() -> Result<()> {
     let aru = AvailableRandomizationUnits::with_client_id(&client_id);
 
     // Here we initialize our main `NimbusClient` struct
-    let nimbus_client = NimbusClient::new(context, "", Some(config), aru)?;
+    let mut nimbus_client = NimbusClient::new(context, "", Some(config), aru)?;
 
     // Explicitly update experiments at least once for init purposes
     nimbus_client.update_experiments()?;

--- a/nimbus/src/client/fs_client.rs
+++ b/nimbus/src/client/fs_client.rs
@@ -31,7 +31,7 @@ impl SettingsClient for FileSystemClient {
         unimplemented!();
     }
 
-    fn get_experiments(&self) -> Result<Vec<Experiment>> {
+    fn get_experiments(&mut self) -> Result<Vec<Experiment>> {
         log::info!("reading experiments in {}", self.path.display());
         let mut res = Vec::new();
         // Skip directories and non .json files (eg, READMEs)

--- a/nimbus/src/client/mod.rs
+++ b/nimbus/src/client/mod.rs
@@ -43,5 +43,5 @@ pub(crate) fn create_client(
 // The trait used to fetch experiments.
 pub(crate) trait SettingsClient {
     fn get_experiments_metadata(&self) -> Result<String>;
-    fn get_experiments(&self) -> Result<Vec<Experiment>>;
+    fn get_experiments(&mut self) -> Result<Vec<Experiment>>;
 }

--- a/nimbus/src/client/null_client.rs
+++ b/nimbus/src/client/null_client.rs
@@ -20,7 +20,7 @@ impl SettingsClient for NullClient {
     fn get_experiments_metadata(&self) -> Result<String> {
         unimplemented!();
     }
-    fn get_experiments(&self) -> Result<Vec<Experiment>> {
+    fn get_experiments(&mut self) -> Result<Vec<Experiment>> {
         Ok(vec![])
     }
 }

--- a/nimbus/src/error.rs
+++ b/nimbus/src/error.rs
@@ -47,6 +47,8 @@ pub enum Error {
     NoSuchExperiment(String),
     #[error("The branch {0} does not exist for the experiment {1}")]
     NoSuchBranch(String, String),
+    #[error("Server asked the client to back off ({0} seconds remaining)")]
+    BackoffError(u64),
 }
 
 // This can be replaced with #[from] in the enum definition

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -122,11 +122,11 @@ impl NimbusClient {
         opt_out(self.db()?, &experiment_slug)
     }
 
-    pub fn update_experiments(&self) -> Result<Vec<EnrollmentChangeEvent>> {
+    pub fn update_experiments(&mut self) -> Result<Vec<EnrollmentChangeEvent>> {
         log::info!("updating experiment list");
+        let new_experiments = self.settings_client.get_experiments()?;
         let db = self.db()?;
         let mut writer = db.write()?;
-        let new_experiments = self.settings_client.get_experiments()?;
         let nimbus_id = self.nimbus_id()?;
         let evolver = EnrollmentsEvolver::new(
             &nimbus_id,

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -50,11 +50,11 @@ enum EnrollmentChangeEventType {
 
 [Error]
 enum Error {
-   "InvalidPersistedData", "RkvError", "IOError",
-   "JSONError", "EvaluationError", "InvalidExpression", "InvalidFraction",
+    "InvalidPersistedData", "RkvError", "IOError",
+    "JSONError", "EvaluationError", "InvalidExpression", "InvalidFraction",
     "TryFromSliceError", "EmptyRatiosError", "OutOfBoundsError","UrlParsingError",
     "RequestError", "ResponseError", "UuidError", "InvalidExperimentResponse",
-    "InvalidPath", "InternalError", "NoSuchExperiment", "NoSuchBranch"
+    "InvalidPath", "InternalError", "NoSuchExperiment", "NoSuchBranch", "BackoffError"
 };
 
 interface NimbusClient {

--- a/nimbus/tests/test_fs_client.rs
+++ b/nimbus/tests/test_fs_client.rs
@@ -33,7 +33,7 @@ fn test_simple() -> Result<()> {
     let tmp_dir = TempDir::new("test_fs_client-test_simple")?;
 
     let aru = Default::default();
-    let client = NimbusClient::new(Default::default(), tmp_dir.path(), Some(config), aru)?;
+    let mut client = NimbusClient::new(Default::default(), tmp_dir.path(), Some(config), aru)?;
     client.update_experiments()?;
 
     let experiments = client.get_all_experiments()?;


### PR DESCRIPTION
Fixes [SDK-15](https://jira.mozilla.com/browse/SDK-15).

I based my implementation on the [Kinto docs](https://docs.kinto-storage.org/en/latest/api/1.x/backoff.html?highlight=retry), the code itself is a spin-off of what we do in the a-s fxa-client.