### PR TITLE
Implement DB upgrade mechanism

### DIFF
--- a/nimbus/src/enrollment.rs
+++ b/nimbus/src/enrollment.rs
@@ -18,6 +18,7 @@ const DEFAULT_GLOBAL_USER_PARTICIPATION: bool = true;
 const PREVIOUS_ENROLLMENTS_GC_TIME: Duration = Duration::from_secs(30 * 24 * 3600);
 
 // These are types we use internally for managing enrollments.
+// ⚠️ Warning : Altering this type might require a DB migration. ⚠️
 #[derive(Deserialize, Serialize, Debug, Clone, Hash, Eq, PartialEq)]
 pub enum EnrolledReason {
     Qualified, // A normal enrollment as per the experiment's rules.
@@ -25,6 +26,7 @@ pub enum EnrolledReason {
 }
 
 // These are types we use internally for managing non-enrollments.
+// ⚠️ Warning : Altering this type might require a DB migration. ⚠️
 #[derive(Deserialize, Serialize, Debug, Clone, Hash, Eq, PartialEq)]
 pub enum NotEnrolledReason {
     OptOut,      // The user opted-out of experiments before we ever got enrolled to this one.
@@ -34,6 +36,7 @@ pub enum NotEnrolledReason {
 }
 
 // These are types we use internally for managing disqualifications.
+// ⚠️ Warning : Altering this type might require a DB migration. ⚠️
 #[derive(Deserialize, Serialize, Debug, Clone, Hash, Eq, PartialEq)]
 pub enum DisqualifiedReason {
     Error,       // There was an error.
@@ -42,6 +45,7 @@ pub enum DisqualifiedReason {
 }
 
 // Every experiment has an ExperimentEnrollment, even when we aren't enrolled.
+// ⚠️ Warning : Altering this type might require a DB migration. ⚠️
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 pub struct ExperimentEnrollment {
     pub slug: String,
@@ -386,7 +390,7 @@ impl ExperimentEnrollment {
         }
     }
 }
-
+// ⚠️ Warning : Altering this type might require a DB migration. ⚠️
 #[derive(Deserialize, Serialize, Debug, Clone, Hash, Eq, PartialEq)]
 pub enum EnrollmentStatus {
     Enrolled {

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -184,6 +184,7 @@ pub const SCHEMA_VERSION: u32 = 1;
 // the schema could be decoupled from the sdk so that it can be iterated on while the
 // sdk depends on a particular version of the schema through the cargo.toml.
 
+// ⚠️ Warning : Altering this type might require a DB migration. ⚠️
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Experiment {
@@ -224,6 +225,7 @@ pub struct FeatureConfig {
     // it yet and the details are still being finalized, so we ignore it for now.
 }
 
+// ⚠️ Warning : Altering this type might require a DB migration. ⚠️
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
 pub struct Branch {
     pub slug: String,
@@ -235,6 +237,7 @@ fn default_buckets() -> u32 {
     DEFAULT_TOTAL_BUCKETS
 }
 
+// ⚠️ Warning : Altering this type might require a DB migration. ⚠️
 #[derive(Deserialize, Serialize, Debug, Default, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct BucketConfig {
@@ -246,6 +249,7 @@ pub struct BucketConfig {
     pub total: u32,
 }
 
+// ⚠️ Warning : Altering this type might require a DB migration. ⚠️
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum RandomizationUnit {


### PR DESCRIPTION
The root cause of the [SDK-149](https://jira.mozilla.com/browse/SDK-149) was that we were trying to deserialize variants that did not exist anymore. I think for this specific migration it is okay to throw everything away and re-populate the database, however for the future db upgrades we will have to do proper migrations.