### PR TITLE
Split update_experiments into two phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased changes
+## What's New
+ - Split up `NimbusClient.update_experiments()` into a slow `NimbusClient.fetch_experiments()` and a fast `NimbusClient.apply_pending_experiments()` to help apps manage concurrency and mutable state.
+ - Add `set_local_experiments(string)`, to help apps, build tooling for tests, and help during startup on first time run.
 
+## ⚠️ Breaking changes ⚠️
+ - `NimbusClient.updateExperiments()` is removed.
+ - Renamed `InvalidExperimentResponse` error to `InvalidExperimentFormat`.
 # 0.6.4 (_2020-12-16_)
 
 ## What's New

--- a/nimbus/examples/experiment.rs
+++ b/nimbus/examples/experiment.rs
@@ -64,8 +64,16 @@ fn main() -> Result<()> {
                 .about("Show all experiments, followed by the enrolled experiments"),
         )
         .subcommand(
+            SubCommand::with_name("fetch-experiments")
+            .about("Fetch experiments from the server. Subsequent calls to apply-pending-experiments will change enrolments."),
+        )
+        .subcommand(
+            SubCommand::with_name("apply-pending-experiments")
+            .about("Updates enrollments with the experiments last fetched from the server with fetch-experiments"),
+        )
+        .subcommand(
             SubCommand::with_name("update-experiments")
-            .about("Updates experiments and enrollments from the server"),
+            .about("Equivalent to fetch-experiments and apply-pending-experiments together"),
         )
         .subcommand(
             SubCommand::with_name("opt-in")
@@ -224,9 +232,19 @@ fn main() -> Result<()> {
                     )
                 });
         }
+        ("fetch-experiments", _) => {
+            println!("======================================");
+            println!("Fetching experiments");
+            nimbus_client.fetch_experiments()?;
+        }
+        ("apply-pending-experiments", _) => {
+            println!("======================================");
+            println!("Applying pending experiments");
+            nimbus_client.apply_pending_experiments()?;
+        }
         ("update-experiments", _) => {
             println!("======================================");
-            println!("Updating experiments");
+            println!("Fetching and applying experiments");
             nimbus_client.fetch_experiments()?;
             nimbus_client.apply_pending_experiments()?;
         }

--- a/nimbus/examples/experiment.rs
+++ b/nimbus/examples/experiment.rs
@@ -199,7 +199,8 @@ fn main() -> Result<()> {
     let mut nimbus_client = NimbusClient::new(context, "", Some(config), aru)?;
 
     // Explicitly update experiments at least once for init purposes
-    nimbus_client.update_experiments()?;
+    nimbus_client.fetch_experiments()?;
+    nimbus_client.apply_pending_experiments()?;
 
     // We match against the subcommands
     match matches.subcommand() {
@@ -226,7 +227,8 @@ fn main() -> Result<()> {
         ("update-experiments", _) => {
             println!("======================================");
             println!("Updating experiments");
-            nimbus_client.update_experiments()?;
+            nimbus_client.fetch_experiments()?;
+            nimbus_client.apply_pending_experiments()?;
         }
         ("opt-in", Some(matches)) => {
             println!("======================================");

--- a/nimbus/src/client/fs_client.rs
+++ b/nimbus/src/client/fs_client.rs
@@ -7,8 +7,8 @@
 //! for tests.
 
 use crate::error::Result;
-use crate::Experiment;
 use crate::SettingsClient;
+use crate::{Experiment, Experiments};
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::BufReader;
@@ -31,7 +31,7 @@ impl SettingsClient for FileSystemClient {
         unimplemented!();
     }
 
-    fn get_experiments(&mut self) -> Result<Vec<Experiment>> {
+    fn fetch_experiments(&mut self) -> Result<Experiments> {
         log::info!("reading experiments in {}", self.path.display());
         let mut res = Vec::new();
         // Skip directories and non .json files (eg, READMEs)
@@ -56,6 +56,6 @@ impl SettingsClient for FileSystemClient {
                 }
             }
         }
-        Ok(res)
+        Ok(Experiments::new(res))
     }
 }

--- a/nimbus/src/client/fs_client.rs
+++ b/nimbus/src/client/fs_client.rs
@@ -7,8 +7,8 @@
 //! for tests.
 
 use crate::error::Result;
+use crate::Experiment;
 use crate::SettingsClient;
-use crate::{Experiment, Experiments};
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::BufReader;
@@ -31,7 +31,7 @@ impl SettingsClient for FileSystemClient {
         unimplemented!();
     }
 
-    fn fetch_experiments(&mut self) -> Result<Experiments> {
+    fn fetch_experiments(&mut self) -> Result<Vec<Experiment>> {
         log::info!("reading experiments in {}", self.path.display());
         let mut res = Vec::new();
         // Skip directories and non .json files (eg, READMEs)
@@ -56,6 +56,6 @@ impl SettingsClient for FileSystemClient {
                 }
             }
         }
-        Ok(Experiments::new(res))
+        Ok(res)
     }
 }

--- a/nimbus/src/client/http_client.rs
+++ b/nimbus/src/client/http_client.rs
@@ -116,17 +116,15 @@ impl SettingsClient for Client {
         );
         let url = self.base_url.join(&path)?;
         let req = Request::get(url);
-        // We first encode the response into a `serde_json::Value`
-        // to allow us to deserialize each experiment individually,
-        // omitting any malformed experiments
         let resp = self.make_request(req)?;
-        let string = resp.text();
-
-        parse_experiments(&string)
+        parse_experiments(&resp.text())
     }
 }
 
 pub fn parse_experiments(payload: &str) -> Result<Vec<Experiment>> {
+    // We first encode the response into a `serde_json::Value`
+    // to allow us to deserialize each experiment individually,
+    // omitting any malformed experiments
     let value: serde_json::Value = serde_json::from_str(payload)?;
     let data = value.get("data").ok_or(Error::InvalidExperimentFormat)?;
     let mut res = Vec::new();

--- a/nimbus/src/client/mod.rs
+++ b/nimbus/src/client/mod.rs
@@ -6,7 +6,7 @@ mod fs_client;
 mod http_client;
 mod null_client;
 use crate::error::{Error, Result};
-use crate::Experiment;
+use crate::Experiments;
 use crate::RemoteSettingsConfig;
 use fs_client::FileSystemClient;
 use http_client::Client;
@@ -43,5 +43,5 @@ pub(crate) fn create_client(
 // The trait used to fetch experiments.
 pub(crate) trait SettingsClient {
     fn get_experiments_metadata(&self) -> Result<String>;
-    fn get_experiments(&mut self) -> Result<Vec<Experiment>>;
+    fn fetch_experiments(&mut self) -> Result<Experiments>;
 }

--- a/nimbus/src/client/mod.rs
+++ b/nimbus/src/client/mod.rs
@@ -6,12 +6,14 @@ mod fs_client;
 mod http_client;
 mod null_client;
 use crate::error::{Error, Result};
-use crate::Experiments;
+use crate::Experiment;
 use crate::RemoteSettingsConfig;
 use fs_client::FileSystemClient;
 use http_client::Client;
 use null_client::NullClient;
 use url::Url;
+
+pub use http_client::parse_experiments;
 
 pub(crate) fn create_client(
     config: Option<RemoteSettingsConfig>,
@@ -43,5 +45,5 @@ pub(crate) fn create_client(
 // The trait used to fetch experiments.
 pub(crate) trait SettingsClient {
     fn get_experiments_metadata(&self) -> Result<String>;
-    fn fetch_experiments(&mut self) -> Result<Experiments>;
+    fn fetch_experiments(&mut self) -> Result<Vec<Experiment>>;
 }

--- a/nimbus/src/client/null_client.rs
+++ b/nimbus/src/client/null_client.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::error::Result;
-use crate::{Experiment, SettingsClient};
+use crate::{Experiments, SettingsClient};
 
 /// This is a client for use when no server is provided.
 /// Its primary use is for non-Mozilla forks of apps that are not using their
@@ -20,8 +20,8 @@ impl SettingsClient for NullClient {
     fn get_experiments_metadata(&self) -> Result<String> {
         unimplemented!();
     }
-    fn get_experiments(&mut self) -> Result<Vec<Experiment>> {
-        Ok(vec![])
+    fn fetch_experiments(&mut self) -> Result<Experiments> {
+        Ok(Default::default())
     }
 }
 
@@ -36,7 +36,8 @@ fn test_null_client() -> Result<()> {
     let tmp_dir = TempDir::new("test_null_client-test_null")?;
 
     let aru = Default::default();
-    let client = NimbusClient::new(Default::default(), tmp_dir.path(), None, aru)?;
+    let mut client = NimbusClient::new(Default::default(), tmp_dir.path(), None, aru)?;
+    client.update_experiments()?;
 
     let experiments = client.get_all_experiments()?;
     assert_eq!(experiments.len(), 0);

--- a/nimbus/src/client/null_client.rs
+++ b/nimbus/src/client/null_client.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use crate::error::Result;
-use crate::{Experiments, SettingsClient};
+use crate::{Experiment, SettingsClient};
 
 /// This is a client for use when no server is provided.
 /// Its primary use is for non-Mozilla forks of apps that are not using their
@@ -20,7 +20,7 @@ impl SettingsClient for NullClient {
     fn get_experiments_metadata(&self) -> Result<String> {
         unimplemented!();
     }
-    fn fetch_experiments(&mut self) -> Result<Experiments> {
+    fn fetch_experiments(&mut self) -> Result<Vec<Experiment>> {
         Ok(Default::default())
     }
 }
@@ -37,7 +37,8 @@ fn test_null_client() -> Result<()> {
 
     let aru = Default::default();
     let mut client = NimbusClient::new(Default::default(), tmp_dir.path(), None, aru)?;
-    client.update_experiments()?;
+    client.fetch_experiments()?;
+    client.apply_pending_experiments()?;
 
     let experiments = client.get_all_experiments()?;
     assert_eq!(experiments.len(), 0);

--- a/nimbus/src/error.rs
+++ b/nimbus/src/error.rs
@@ -38,7 +38,7 @@ pub enum Error {
     #[error("Error in network response: {0}")]
     ResponseError(String),
     #[error("Invalid experiments response received")]
-    InvalidExperimentResponse,
+    InvalidExperimentFormat,
     #[error("Invalid path: {0}")]
     InvalidPath(String),
     #[error("Internal error: {0}")]

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -11,6 +11,7 @@ mod config;
 mod matcher;
 mod persistence;
 mod sampling;
+mod updating;
 #[cfg(debug_assertions)]
 pub use evaluator::evaluate_enrollment;
 
@@ -25,7 +26,9 @@ pub use matcher::AppContext;
 use once_cell::sync::OnceCell;
 use persistence::{Database, StoreId};
 use serde_derive::*;
+use std::convert::TryFrom;
 use std::path::PathBuf;
+use updating::{pop_pending_updates, stash_pending_updates};
 use uuid::Uuid;
 
 const DEFAULT_TOTAL_BUCKETS: u32 = 10000;
@@ -123,19 +126,45 @@ impl NimbusClient {
     }
 
     pub fn update_experiments(&mut self) -> Result<Vec<EnrollmentChangeEvent>> {
+        self.fetch_experiments()?;
+        self.apply_pending_updates()
+    }
+
+    pub fn fetch_experiments(&mut self) -> Result<()> {
+        log::info!("fetching experiments");
+        let new_experiments = self.settings_client.fetch_experiments()?;
+        stash_pending_updates(self.db()?, new_experiments)?;
+        Ok(())
+    }
+
+    pub fn apply_pending_updates(&self) -> Result<Vec<EnrollmentChangeEvent>> {
         log::info!("updating experiment list");
-        let new_experiments = self.settings_client.get_experiments()?;
         let db = self.db()?;
         let mut writer = db.write()?;
-        let nimbus_id = self.nimbus_id()?;
-        let evolver = EnrollmentsEvolver::new(
-            &nimbus_id,
-            &self.available_randomization_units,
-            &self.app_context,
-        );
-        let events = evolver.evolve_enrollments_in_db(db, &mut writer, &new_experiments)?;
-        writer.commit()?;
-        Ok(events)
+        let pending_updates = pop_pending_updates(db, &mut writer)?;
+        Ok(match pending_updates {
+            Some(updates) => {
+                let new_experiments = updates.get_experiments();
+                let nimbus_id = self.nimbus_id()?;
+                let evolver = EnrollmentsEvolver::new(
+                    &nimbus_id,
+                    &self.available_randomization_units,
+                    &self.app_context,
+                );
+                let events = evolver.evolve_enrollments_in_db(db, &mut writer, new_experiments)?;
+                writer.commit()?;
+                events
+            }
+            // We don't need to writer.commit() here because we haven't done anything.
+            None => vec![],
+        })
+    }
+
+    pub fn set_experiments_locally(&self, experiments_json: String) -> Result<()> {
+        let json = serde_json::from_str::<serde_json::Value>(&experiments_json)?;
+        let new_experiments = Experiments::try_from(json)?;
+        stash_pending_updates(self.db()?, new_experiments)?;
+        Ok(())
     }
 
     pub fn nimbus_id(&self) -> Result<Uuid> {
@@ -213,6 +242,20 @@ impl Experiment {
         self.branches
             .iter()
             .any(|branch| branch.slug == branch_slug)
+    }
+}
+
+#[derive(Deserialize, Serialize, Debug, Default, Clone)]
+pub struct Experiments {
+    data: Vec<Experiment>,
+}
+
+impl Experiments {
+    fn new(data: Vec<Experiment>) -> Self {
+        Experiments { data }
+    }
+    fn get_experiments(&self) -> &Vec<Experiment> {
+        &self.data
     }
 }
 

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -88,11 +88,30 @@ interface NimbusClient {
     [Throws=Error]
     sequence<EnrollmentChangeEvent> set_global_user_participation(boolean opt_in);
 
-    // Updates the list of experiments from the server. After calling this, the
-    // list of active experiments might change (there might be new experiments,
-    // or old experiments might have expired)
+    // Updates the list of experiments from the server.
+    // This method is deprecated, in favour of calling `fetch_experiments()` and then
+    // `apply_pending_updates()`.
     [Throws=Error]
     sequence<EnrollmentChangeEvent> update_experiments();
+
+    // Fetches the list of experiments from the server. This does not affect the list
+    // of active experiments or experiment enrolment.
+    // Fetched experiments are not applied until `apply_pending_updates()` is called.
+    [Throws=Error]
+    void fetch_experiments();
+
+    // Apply the updated experiments from the last fetch.
+    // After calling this, the list of active experiments might change
+    // (there might be new experiments, or old experiments might have expired).
+    [Throws=Error]
+    sequence<EnrollmentChangeEvent> apply_pending_updates();
+
+    // A convenience method for apps to set the experiments from a local source
+    // for either testing, or before the first fetch has finished.
+    // 
+    // Experiments set with this method are not applied until `apply_pending_updates()` is called.
+    [Throws=Error]
+    void set_experiments_locally(string experiments_json);
 
     // These are test-only functions and should never be exposed to production
     // users, as they mess with the "statistical requirements" of the SDK.

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -54,7 +54,7 @@ enum Error {
     "InvalidPersistedData", "RkvError", "IOError",
     "JSONError", "EvaluationError", "InvalidExpression", "InvalidFraction",
     "TryFromSliceError", "EmptyRatiosError", "OutOfBoundsError","UrlParsingError",
-    "RequestError", "ResponseError", "UuidError", "InvalidExperimentResponse",
+    "RequestError", "ResponseError", "UuidError", "InvalidExperimentFormat",
     "InvalidPath", "InternalError", "NoSuchExperiment", "NoSuchBranch", "BackoffError"
 };
 
@@ -104,7 +104,7 @@ interface NimbusClient {
     // After calling this, the list of active experiments might change
     // (there might be new experiments, or old experiments might have expired).
     [Throws=Error]
-    sequence<EnrollmentChangeEvent> apply_pending_updates();
+    sequence<EnrollmentChangeEvent> apply_pending_experiments();
 
     // A convenience method for apps to set the experiments from a local source
     // for either testing, or before the first fetch has finished.

--- a/nimbus/src/persistence.rs
+++ b/nimbus/src/persistence.rs
@@ -186,6 +186,11 @@ impl Database {
                 self.enrollment_store.clear(&mut writer)?;
             }
         }
+        // It is safe to clear the update store (i.e. the pending experiments) on all schema upgrades
+        // as it will be re-filled from the server on the next `fetch_experiments()`.
+        // The current contents of the update store may cause experiments to not load, or worse,
+        // accidentally unenrol.
+        self.updates_store.clear(&mut writer)?;
         self.meta_store
             .put(&mut writer, DB_KEY_DB_VERSION, &DB_VERSION)?;
         writer.commit()?;

--- a/nimbus/src/persistence.rs
+++ b/nimbus/src/persistence.rs
@@ -58,6 +58,7 @@ pub enum StoreId {
     Experiments,
     Enrollments,
     Meta,
+    Updates,
 }
 
 /// A wrapper for an Rkv store. Implemented to allow any value which supports
@@ -140,6 +141,7 @@ pub struct Database {
     meta_store: SingleStore,
     experiment_store: SingleStore,
     enrollment_store: SingleStore,
+    updates_store: SingleStore,
 }
 
 impl Database {
@@ -152,11 +154,13 @@ impl Database {
         let meta_store = rkv.open_single("meta", StoreOptions::create())?;
         let experiment_store = rkv.open_single("experiments", StoreOptions::create())?;
         let enrollment_store = rkv.open_single("enrollments", StoreOptions::create())?;
+        let updates_store = rkv.open_single("updates", StoreOptions::create())?;
         let db = Self {
             rkv,
             meta_store: SingleStore::new(meta_store),
             experiment_store: SingleStore::new(experiment_store),
             enrollment_store: SingleStore::new(enrollment_store),
+            updates_store: SingleStore::new(updates_store),
         };
         db.maybe_upgrade()?;
         Ok(db)
@@ -195,6 +199,7 @@ impl Database {
             StoreId::Meta => &self.meta_store,
             StoreId::Experiments => &self.experiment_store,
             StoreId::Enrollments => &self.enrollment_store,
+            StoreId::Updates => &self.updates_store,
         }
     }
 

--- a/nimbus/src/sampling.rs
+++ b/nimbus/src/sampling.rs
@@ -143,7 +143,7 @@ fn is_hash_in_bucket(
 /// # Errors
 /// returns an error if the fraction not within the 0-1 range
 fn fraction_to_key(fraction: f64) -> Result<String> {
-    if fraction < 0.0 || fraction > 1.0 {
+    if !(0.0..=1.0).contains(&fraction) {
         return Err(Error::InvalidFraction);
     }
     let multiplied = (fraction * (2u64.pow(HASH_BITS) - 1) as f64).floor();

--- a/nimbus/src/updating.rs
+++ b/nimbus/src/updating.rs
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! This module implements the primitive functions to implement
+//! safe updating from the server.
+
+use crate::error::Result;
+use crate::persistence::{Database, StoreId, Writer};
+use crate::Experiments;
+
+const KEY_PENDING_UPDATES: &str = "pending-experiment-updates";
+
+pub fn stash_pending_updates(db: &Database, experiments: Experiments) -> Result<()> {
+    let mut writer = db.write()?;
+    db.get_store(StoreId::Updates)
+        .put(&mut writer, KEY_PENDING_UPDATES, &experiments)?;
+    writer.commit()?;
+    Ok(())
+}
+
+pub fn pop_pending_updates(db: &Database, writer: &mut Writer) -> Result<Option<Experiments>> {
+    let store = db.get_store(StoreId::Updates);
+    let experiments = store.get::<Experiments>(writer, KEY_PENDING_UPDATES)?;
+
+    if let Some(_) = experiments {
+        store.clear(writer)?;
+    }
+
+    Ok(experiments)
+}
+
+#[cfg(feature = "rkv-safe-mode")]
+#[test]
+fn test_stash_pop() -> Result<()> {
+    use crate::Experiment;
+    use tempdir::TempDir;
+
+    let tmp_dir = TempDir::new("test_stash_pop_updates")?;
+    let db = Database::new(&tmp_dir)?;
+
+    let _ = env_logger::try_init();
+
+    let test_experiment: Experiment = Default::default();
+    let fetched = Experiments::new(vec![test_experiment]);
+
+    // simulated fetch by constructing a dummy payload of 1 experiment.
+    assert_eq!(fetched.get_experiments().len(), 1);
+
+    stash_pending_updates(&db, fetched)?;
+
+    // Now, we come to get the stashed updates, and they should be
+    // the same.
+    let mut writer = db.write()?;
+    let pending = pop_pending_updates(&db, &mut writer)?;
+    writer.commit()?;
+
+    assert_eq!(pending.unwrap().get_experiments().len(), 1);
+
+    // After we've fetched this once, we should have no pending
+    // updates left.
+    let mut writer = db.write()?;
+    let pending = pop_pending_updates(&db, &mut writer)?;
+    writer.commit()?;
+
+    if let Some(_) = pending {
+        assert!(false, "No pending updates should be stashed");
+    }
+
+    Ok(())
+}

--- a/nimbus/tests/test_fs_client.rs
+++ b/nimbus/tests/test_fs_client.rs
@@ -34,7 +34,8 @@ fn test_simple() -> Result<()> {
 
     let aru = Default::default();
     let mut client = NimbusClient::new(Default::default(), tmp_dir.path(), Some(config), aru)?;
-    client.update_experiments()?;
+    client.fetch_experiments()?;
+    client.apply_pending_experiments()?;
 
     let experiments = client.get_all_experiments()?;
     assert_eq!(experiments.len(), 1);

--- a/nimbus/tests/test_updates.rs
+++ b/nimbus/tests/test_updates.rs
@@ -1,0 +1,201 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// Testing the two phase updates.
+// This test crashes lmdb for reasons that make no sense, so only run it
+// in the "safe mode" backend.
+#[cfg(feature = "rkv-safe-mode")]
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "rkv-safe-mode")]
+    use nimbus::{error::Result, AppContext, NimbusClient, RemoteSettingsConfig};
+
+    fn initial_experiments() -> String {
+        use serde_json::json;
+        json!({
+            "data": [
+                {
+                    "schemaVersion": "1.0.0",
+                    "slug": "startup-gold",
+                    "endDate": null,
+                    "branches":[
+                        {"slug": "control", "ratio": 1},
+                        {"slug": "treatment","ratio":1}
+                    ],
+                    "probeSets":[],
+                    "startDate":null,
+                    "application":"fenix",
+                    "bucketConfig":{
+                        // Setup to enroll everyone by default.
+                        "count":10_000,
+                        "start":0,
+                        "total":10_000,
+                        "namespace":"startup-gold",
+                        "randomizationUnit":"nimbus_id"
+                    },
+                    "userFacingName":"Diagnostic test experiment",
+                    "referenceBranch":"control",
+                    "isEnrollmentPaused":false,
+                    "proposedEnrollment":7,
+                    "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+                    "id":"secure-gold",
+                    "last_modified":1_602_197_324_372i64
+                },
+                {
+                    "schemaVersion": "1.0.0",
+                    "slug": "secure-gold",
+                    "endDate": null,
+                    "branches":[
+                        {"slug": "control", "ratio": 1},
+                        {"slug": "treatment","ratio":1}
+                    ],
+                    "probeSets":[],
+                    "startDate":null,
+                    "application":"fenix",
+                    "bucketConfig":{
+                        // Setup to enroll everyone by default.
+                        "count":10_000,
+                        "start":0,
+                        "total":10_000,
+                        "namespace":"secure-gold",
+                        "randomizationUnit":"nimbus_id"
+                    },
+                    "userFacingName":"Diagnostic test experiment",
+                    "referenceBranch":"control",
+                    "isEnrollmentPaused":false,
+                    "proposedEnrollment":7,
+                    "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+                    "id":"secure-gold",
+                    "last_modified":1_602_197_324_372i64
+                }
+            ]
+        })
+        .to_string()
+    }
+
+    fn no_experiments() -> String {
+        use serde_json::json;
+        json!({
+            "data": []
+        })
+        .to_string()
+    }
+
+    fn new_client(identifier: &str) -> Result<NimbusClient> {
+        use std::path::PathBuf;
+        use tempdir::TempDir;
+        use url::Url;
+        let _ = env_logger::try_init();
+        let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        dir.push("tests/experiments");
+        let tmp_dir = TempDir::new(identifier)?;
+        let url = Url::from_file_path(dir).expect("experiments dir should exist");
+
+        let config = RemoteSettingsConfig {
+            server_url: url.as_str().to_string(),
+            bucket_name: "doesn't matter".to_string(),
+            collection_name: "doesn't matter".to_string(),
+        };
+        let aru = Default::default();
+        let ctx = AppContext {
+            app_id: "fenix".to_string(),
+            ..Default::default()
+        };
+        NimbusClient::new(ctx, tmp_dir.path(), Some(config), aru)
+    }
+
+    fn startup(client: &mut NimbusClient, first_run: bool) -> Result<()> {
+        if first_run {
+            client.set_experiments_locally(initial_experiments())?;
+        }
+        client.apply_pending_updates()?;
+        client.fetch_experiments()?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_two_phase_update() -> Result<()> {
+        let mut client = new_client("test_two_phase_update")?;
+        client.fetch_experiments()?;
+
+        // We have fetched the experiments from the server, but not put them into use yet.
+        // The experiments are pending.
+        let experiments = client.get_all_experiments()?;
+        assert_eq!(experiments.len(), 0);
+
+        // Now, the app chooses when to apply the pending updates to the experiments.
+        let events: Vec<_> = client.apply_pending_updates()?;
+        assert_eq!(events.len(), 1);
+
+        let experiments = client.get_all_experiments()?;
+        assert_eq!(experiments.len(), 1);
+        assert_eq!(experiments[0].slug, "secure-gold");
+
+        // Next time we start the app, we immediately apply pending updates,
+        // but there may not be any waiting.
+        let events: Vec<_> = client.apply_pending_updates()?;
+        // No change events
+        assert_eq!(events.len(), 0);
+
+        // Confirm that nothing has changed.
+        let experiments = client.get_all_experiments()?;
+        assert_eq!(experiments.len(), 1);
+        assert_eq!(experiments[0].slug, "secure-gold");
+
+        Ok(())
+    }
+
+    fn assert_experiment_count(client: &NimbusClient, count: usize) -> Result<()> {
+        let experiments = client.get_all_experiments()?;
+        assert_eq!(experiments.len(), count);
+        Ok(())
+    }
+
+    #[cfg(feature = "rkv-safe-mode")]
+    #[test]
+    fn test_set_experiments_locally() -> Result<()> {
+        let client = new_client("test_set_experiments_locally")?;
+        assert_experiment_count(&client, 0)?;
+
+        client.set_experiments_locally(initial_experiments())?;
+        assert_experiment_count(&client, 0)?;
+
+        client.apply_pending_updates()?;
+        assert_experiment_count(&client, 2)?;
+
+        client.set_experiments_locally(no_experiments())?;
+        assert_experiment_count(&client, 2)?;
+
+        client.apply_pending_updates()?;
+        assert_experiment_count(&client, 0)?;
+
+        Ok(())
+    }
+
+    #[cfg(feature = "rkv-safe-mode")]
+    #[test]
+    fn test_startup_behavior() -> Result<()> {
+        let mut client = new_client("test_startup_behavior")?;
+        startup(&mut client, true)?;
+
+        let experiments = client.get_all_experiments()?;
+        assert_eq!(experiments.len(), 2);
+        assert_eq!(experiments[0].slug, "secure-gold");
+        assert_eq!(experiments[1].slug, "startup-gold");
+
+        // The app is at a safe place to change all the experiments.
+        client.apply_pending_updates()?;
+        let experiments = client.get_all_experiments()?;
+        assert_eq!(experiments.len(), 1);
+        assert_eq!(experiments[0].slug, "secure-gold");
+
+        // Next time we start the app.
+        startup(&mut client, false)?;
+        let experiments = client.get_all_experiments()?;
+        assert_eq!(experiments.len(), 1);
+        assert_eq!(experiments[0].slug, "secure-gold");
+
+        Ok(())
+    }
+}

--- a/nimbus/tests/test_updates.rs
+++ b/nimbus/tests/test_updates.rs
@@ -109,7 +109,7 @@ mod test {
         if first_run {
             client.set_experiments_locally(initial_experiments())?;
         }
-        client.apply_pending_updates()?;
+        client.apply_pending_experiments()?;
         client.fetch_experiments()?;
         Ok(())
     }
@@ -125,7 +125,7 @@ mod test {
         assert_eq!(experiments.len(), 0);
 
         // Now, the app chooses when to apply the pending updates to the experiments.
-        let events: Vec<_> = client.apply_pending_updates()?;
+        let events: Vec<_> = client.apply_pending_experiments()?;
         assert_eq!(events.len(), 1);
 
         let experiments = client.get_all_experiments()?;
@@ -134,7 +134,7 @@ mod test {
 
         // Next time we start the app, we immediately apply pending updates,
         // but there may not be any waiting.
-        let events: Vec<_> = client.apply_pending_updates()?;
+        let events: Vec<_> = client.apply_pending_experiments()?;
         // No change events
         assert_eq!(events.len(), 0);
 
@@ -161,13 +161,13 @@ mod test {
         client.set_experiments_locally(initial_experiments())?;
         assert_experiment_count(&client, 0)?;
 
-        client.apply_pending_updates()?;
+        client.apply_pending_experiments()?;
         assert_experiment_count(&client, 2)?;
 
         client.set_experiments_locally(no_experiments())?;
         assert_experiment_count(&client, 2)?;
 
-        client.apply_pending_updates()?;
+        client.apply_pending_experiments()?;
         assert_experiment_count(&client, 0)?;
 
         Ok(())
@@ -185,7 +185,7 @@ mod test {
         assert_eq!(experiments[1].slug, "startup-gold");
 
         // The app is at a safe place to change all the experiments.
-        client.apply_pending_updates()?;
+        client.apply_pending_experiments()?;
         let experiments = client.get_all_experiments()?;
         assert_eq!(experiments.len(), 1);
         assert_eq!(experiments[0].slug, "secure-gold");


### PR DESCRIPTION
This PR addresses [SDK-142][1].

We split the `update_experiments` method in two to give the [app more control][2] over when experiment changes happen.

Two methods (`set_experiments_locally` and `fetch_experiments`) stash the experiments in a new rkv table called `Updates`.

This table is managed by the methods in `updating.rs`, which provides methods `stash` and a `pop` the updates.

The function `apply_pending_updates` is largely the same as `update_experiments`, but gets its `Experiment`s from the stashed updates. 

`Client::get_experiments` and `http_client::Client::get_experiments` has changed to as to re-use the fault-tolerant deserialization of experiments for both `http_client` and from the new `set_experiments_locally`.

[1]: https://jira.mozilla.com/browse/SDK-142
[2]: https://docs.google.com/document/d/19cPhEV00gmG_BAhvoPDK1eYPtMWVgqmiHxE-xwLSnW0/edit#