### PR TITLE
Add `reset_telemetry_identifiers` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # Unreleased changes
+
 ## What's New
- - Split up `NimbusClient.update_experiments()` into a slow `NimbusClient.fetch_experiments()` and a fast `NimbusClient.apply_pending_experiments()` to help apps manage concurrency and mutable state.
- - Add `set_local_experiments(string)`, to help apps, build tooling for tests, and help during startup on first time run.
+
+- Split up `NimbusClient.update_experiments()` into a slow `NimbusClient.fetch_experiments()`
+  and a fast `NimbusClient.apply_pending_experiments()` to help apps manage concurrency and
+  mutable state.
+- Add `set_local_experiments(string)`, to help apps, build tooling for tests, and help during
+  startup on first time run.
+- A new `reset_telemetry_identifiers` method has been added; consumers should arrange to call
+  this method if the user opts out of telemetry at the application level, in order to avoid
+  accidental tracking of users who disable then re-enable telemetry.
 
 ## ⚠️ Breaking changes ⚠️
- - `NimbusClient.updateExperiments()` is removed.
- - Renamed `InvalidExperimentResponse` error to `InvalidExperimentFormat`.
+- `NimbusClient.updateExperiments()` is removed.
+- Renamed `InvalidExperimentResponse` error to `InvalidExperimentFormat`.
+
 # 0.6.4 (_2020-12-16_)
 
 ## What's New

--- a/nimbus/src/enrollment.rs
+++ b/nimbus/src/enrollment.rs
@@ -149,36 +149,20 @@ impl ExperimentEnrollment {
                     updated_enrollment
                 }
             }
-            EnrollmentStatus::Enrolled {
-                ref branch,
-                enrollment_id,
-                ..
-            } => {
+            EnrollmentStatus::Enrolled { ref branch, .. } => {
                 if !is_user_participating {
                     log::debug!(
                         "Existing experiment enrollment '{}' is now disqualified (global opt-out)",
                         &self.slug
                     );
-                    let updated_enrollment = Self {
-                        slug: self.slug.clone(),
-                        status: EnrollmentStatus::Disqualified {
-                            reason: DisqualifiedReason::OptOut,
-                            enrollment_id,
-                            branch: branch.clone(),
-                        },
-                    };
+                    let updated_enrollment =
+                        self.disqualify_from_enrolled(DisqualifiedReason::OptOut);
                     out_enrollment_events.push(updated_enrollment.get_change_event());
                     updated_enrollment
                 } else if !updated_experiment.has_branch(branch) {
                     // The branch we were in disappeared!
-                    let updated_enrollment = Self {
-                        slug: self.slug.clone(),
-                        status: EnrollmentStatus::Disqualified {
-                            reason: DisqualifiedReason::Error,
-                            enrollment_id,
-                            branch: branch.clone(),
-                        },
-                    };
+                    let updated_enrollment =
+                        self.disqualify_from_enrolled(DisqualifiedReason::Error);
                     out_enrollment_events.push(updated_enrollment.get_change_event());
                     updated_enrollment
                 } else {
@@ -190,14 +174,8 @@ impl ExperimentEnrollment {
                     )?;
                     match evaluated_enrollment.status {
                         EnrollmentStatus::Error { .. } => {
-                            let updated_enrollment = Self {
-                                slug: self.slug.clone(),
-                                status: EnrollmentStatus::Disqualified {
-                                    reason: DisqualifiedReason::Error,
-                                    enrollment_id,
-                                    branch: branch.clone(),
-                                },
-                            };
+                            let updated_enrollment =
+                                self.disqualify_from_enrolled(DisqualifiedReason::Error);
                             out_enrollment_events.push(updated_enrollment.get_change_event());
                             updated_enrollment
                         }
@@ -205,14 +183,8 @@ impl ExperimentEnrollment {
                             reason: NotEnrolledReason::NotTargeted,
                         } => {
                             log::debug!("Existing experiment enrollment '{}' is now disqualified (targeting change)", &self.slug);
-                            let updated_enrollment = Self {
-                                slug: self.slug.clone(),
-                                status: EnrollmentStatus::Disqualified {
-                                    reason: DisqualifiedReason::NotTargeted,
-                                    enrollment_id,
-                                    branch: branch.clone(),
-                                },
-                            };
+                            let updated_enrollment =
+                                self.disqualify_from_enrolled(DisqualifiedReason::NotTargeted);
                             out_enrollment_events.push(updated_enrollment.get_change_event());
                             updated_enrollment
                         }
@@ -296,19 +268,8 @@ impl ExperimentEnrollment {
         out_enrollment_events: &mut Vec<EnrollmentChangeEvent>,
     ) -> Result<Self> {
         Ok(match self.status {
-            EnrollmentStatus::Enrolled {
-                enrollment_id,
-                ref branch,
-                ..
-            } => {
-                let enrollment = Self {
-                    slug: self.slug.to_string(),
-                    status: EnrollmentStatus::Disqualified {
-                        reason: DisqualifiedReason::OptOut,
-                        branch: branch.to_owned(),
-                        enrollment_id,
-                    },
-                };
+            EnrollmentStatus::Enrolled { .. } => {
+                let enrollment = self.disqualify_from_enrolled(DisqualifiedReason::OptOut);
                 out_enrollment_events.push(enrollment.get_change_event());
                 enrollment
             }
@@ -325,6 +286,37 @@ impl ExperimentEnrollment {
                 self.clone()
             }
         })
+    }
+
+    /// Reset identifiers in response to application-level telemetry reset.
+    ///
+    /// Each experiment enrollment record contains a unique `enrollment_id`. When the user
+    /// resets their application-level telemetry, we reset each such id to a special nil value,
+    /// creating a clean break between data sent before the reset and any data that might be
+    /// submitted about these enrollments in future.
+    ///
+    /// We also move any enrolled experiments to the "disqualified" state, since their further
+    /// partipation would submit partial data that could skew analysis.
+    ///
+    fn reset_telemetry_identifiers(
+        &self,
+        out_enrollment_events: &mut Vec<EnrollmentChangeEvent>,
+    ) -> Self {
+        let updated = match self.status {
+            EnrollmentStatus::Enrolled { .. } => {
+                let disqualified = self.disqualify_from_enrolled(DisqualifiedReason::OptOut);
+                out_enrollment_events.push(disqualified.get_change_event());
+                disqualified
+            }
+            EnrollmentStatus::NotEnrolled { .. }
+            | EnrollmentStatus::Disqualified { .. }
+            | EnrollmentStatus::WasEnrolled { .. }
+            | EnrollmentStatus::Error { .. } => self.clone(),
+        };
+        ExperimentEnrollment {
+            status: updated.status.clone_with_nil_enrollment_id(),
+            ..updated
+        }
     }
 
     /// Garbage collect old experiments we've kept a WasEnrolled enrollment from.
@@ -389,7 +381,30 @@ impl ExperimentEnrollment {
             EnrollmentStatus::NotEnrolled { .. } | EnrollmentStatus::Error { .. } => unreachable!(),
         }
     }
+
+    /// If the current state is `Enrolled`, move to `Disqualified` with the given reason.
+    fn disqualify_from_enrolled(&self, reason: DisqualifiedReason) -> Self {
+        match self.status {
+            EnrollmentStatus::Enrolled {
+                ref enrollment_id,
+                ref branch,
+                ..
+            } => ExperimentEnrollment {
+                status: EnrollmentStatus::Disqualified {
+                    reason,
+                    enrollment_id: enrollment_id.to_owned(),
+                    branch: branch.to_owned(),
+                },
+                ..self.clone()
+            },
+            EnrollmentStatus::NotEnrolled { .. }
+            | EnrollmentStatus::Disqualified { .. }
+            | EnrollmentStatus::WasEnrolled { .. }
+            | EnrollmentStatus::Error { .. } => self.clone(),
+        }
+    }
 }
+
 // ⚠️ Warning : Altering this type might require a DB migration. ⚠️
 #[derive(Deserialize, Serialize, Debug, Clone, Hash, Eq, PartialEq)]
 pub enum EnrollmentStatus {
@@ -427,11 +442,33 @@ impl EnrollmentStatus {
             enrollment_id: Uuid::new_v4(),
         }
     }
+
     // This is used in examples, but not in the main dylib, and
     // triggers a dead code warning when building with `--release`.
     #[allow(dead_code)]
     pub fn is_enrolled(&self) -> bool {
         matches!(self, EnrollmentStatus::Enrolled { .. })
+    }
+
+    /// Make a clone of this status, but with the special nil enrollment_id.
+    fn clone_with_nil_enrollment_id(&self) -> Self {
+        let mut updated = self.clone();
+        match updated {
+            EnrollmentStatus::Enrolled {
+                ref mut enrollment_id,
+                ..
+            }
+            | EnrollmentStatus::Disqualified {
+                ref mut enrollment_id,
+                ..
+            }
+            | EnrollmentStatus::WasEnrolled {
+                ref mut enrollment_id,
+                ..
+            } => *enrollment_id = Uuid::nil(),
+            EnrollmentStatus::NotEnrolled { .. } | EnrollmentStatus::Error { .. } => (),
+        };
+        updated
     }
 }
 
@@ -713,6 +750,25 @@ pub fn set_global_user_participation(
 ) -> Result<()> {
     let store = db.get_store(StoreId::Meta);
     store.put(writer, DB_KEY_GLOBAL_USER_PARTICIPATION, &opt_in)
+}
+
+/// Reset unique identifiers in response to application-level telemetry reset.
+///
+pub fn reset_telemetry_identifiers(
+    db: &Database,
+    writer: &mut Writer,
+) -> Result<Vec<EnrollmentChangeEvent>> {
+    let mut events = vec![];
+    let store = db.get_store(StoreId::Enrollments);
+    let enrollments = store.collect_all::<ExperimentEnrollment>(&writer)?;
+    let updated_enrollments = enrollments
+        .iter()
+        .map(|enrollment| enrollment.reset_telemetry_identifiers(&mut events));
+    store.clear(writer)?;
+    for enrollment in updated_enrollments {
+        store.put(writer, &enrollment.slug, &enrollment)?;
+    }
+    Ok(events)
 }
 
 fn now_secs() -> u64 {
@@ -1882,6 +1938,111 @@ mod tests {
             })
             .collect();
         assert_eq!(disqualified_enrollments.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_telemetry_reset() -> Result<()> {
+        let _ = env_logger::try_init();
+        let tmp_dir = TempDir::new("test_telemetry_reset")?;
+        let db = Database::new(&tmp_dir)?;
+        let mut writer = db.write()?;
+
+        let mock_exp1_slug = "exp-1".to_string();
+        let mock_exp1_branch = "branch-1".to_string();
+        let mock_exp2_slug = "exp-2".to_string();
+        let mock_exp2_branch = "branch-2".to_string();
+        let mock_exp3_slug = "exp-3".to_string();
+
+        // Three currently-known experiments, in different states.
+        let store = db.get_store(StoreId::Enrollments);
+        store.put(
+            &mut writer,
+            &mock_exp1_slug,
+            &ExperimentEnrollment {
+                slug: mock_exp1_slug.clone(),
+                status: EnrollmentStatus::new_enrolled(
+                    EnrolledReason::Qualified,
+                    &mock_exp1_branch,
+                ),
+            },
+        )?;
+        store.put(
+            &mut writer,
+            &mock_exp2_slug,
+            &ExperimentEnrollment {
+                slug: mock_exp2_slug.clone(),
+                status: EnrollmentStatus::Disqualified {
+                    reason: DisqualifiedReason::Error,
+                    branch: mock_exp2_branch.clone(),
+                    enrollment_id: Uuid::new_v4(),
+                },
+            },
+        )?;
+        store.put(
+            &mut writer,
+            &mock_exp3_slug,
+            &ExperimentEnrollment {
+                slug: mock_exp3_slug.clone(),
+                status: EnrollmentStatus::NotEnrolled {
+                    reason: NotEnrolledReason::NotTargeted,
+                },
+            },
+        )?;
+        writer.commit()?;
+
+        let mut writer = db.write()?;
+        let events = reset_telemetry_identifiers(&db, &mut writer)?;
+        writer.commit()?;
+
+        let enrollments = db.collect_all::<ExperimentEnrollment>(StoreId::Enrollments)?;
+        assert_eq!(enrollments.len(), 3);
+
+        // The enrolled experiment should have moved to disqualified with nil enrollment_id.
+        assert_eq!(enrollments[0].slug, mock_exp1_slug);
+        assert!(
+            matches!(&enrollments[0].status, EnrollmentStatus::Disqualified {
+                reason: DisqualifiedReason::OptOut,
+                branch,
+                enrollment_id,
+                ..
+            } if *branch == mock_exp1_branch && enrollment_id.is_nil())
+        );
+
+        // The disqualified experiment should have stayed disqualified, with nil enrollment_id.
+        assert_eq!(enrollments[1].slug, mock_exp2_slug);
+        assert!(
+            matches!(&enrollments[1].status, EnrollmentStatus::Disqualified {
+                reason: DisqualifiedReason::Error,
+                branch,
+                enrollment_id,
+                ..
+            } if *branch == mock_exp2_branch && enrollment_id.is_nil())
+        );
+
+        // The not-enrolled experiment should have been unchanged.
+        assert_eq!(enrollments[2].slug, mock_exp3_slug);
+        assert!(
+            matches!(&enrollments[2].status, EnrollmentStatus::NotEnrolled {
+                reason: NotEnrolledReason::NotTargeted,
+                ..
+            })
+        );
+
+        // We should have returned a single disqualification event.
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], EnrollmentChangeEvent {
+            change: EnrollmentChangeEventType::Disqualification,
+            reason: Some(reason),
+            experiment_slug,
+            branch_slug,
+            enrollment_id,
+        } if reason == "optout"
+            && *experiment_slug == mock_exp1_slug
+            && *branch_slug == mock_exp1_branch
+            && ! Uuid::parse_str(&enrollment_id)?.is_nil()
+        ));
+
         Ok(())
     }
 }

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -174,6 +174,36 @@ impl NimbusClient {
         Ok(())
     }
 
+    /// Reset internal state in response to application-level telemetry reset.
+    ///
+    /// When the user resets their telemetry state in the consuming application, we need learn
+    /// the new values of any external randomization units, and we need to reset any unique
+    /// identifiers used internally by the SDK. If we don't then we risk accidentally tracking
+    /// across the telemetry reset, since we could use Nimbus metrics to link their pings from
+    /// before and after the reset.
+    ///
+    pub fn reset_telemetry_identifiers(
+        &mut self,
+        new_randomization_units: AvailableRandomizationUnits,
+    ) -> Result<Vec<EnrollmentChangeEvent>> {
+        let mut events = vec![];
+        let db = self.db()?;
+        let mut writer = db.write()?;
+        // If we have no `nimbus_id` when we can safely assume that there's
+        // no other experiment state that needs to be reset.
+        let store = db.get_store(StoreId::Meta);
+        if store.get::<String>(&writer, DB_KEY_NIMBUS_ID)?.is_some() {
+            // Each enrollment state includes a unique `enrollment_id` which we need to clear.
+            events = enrollment::reset_telemetry_identifiers(db, &mut writer)?;
+            // The `nimbus_id` itself is a unique identifier.
+            // N.B. we do this last, as a signal that all data has been reset.
+            store.delete(&mut writer, DB_KEY_NIMBUS_ID)?;
+        }
+        writer.commit()?;
+        self.available_randomization_units = new_randomization_units;
+        Ok(events)
+    }
+
     pub fn nimbus_id(&self) -> Result<Uuid> {
         let db = self.db()?;
         let mut writer = db.write()?;
@@ -331,3 +361,76 @@ impl AvailableRandomizationUnits {
 
 #[cfg(feature = "uniffi-bindings")]
 include!(concat!(env!("OUT_DIR"), "/nimbus.uniffi.rs"));
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use enrollment::{EnrolledReason, EnrollmentStatus, ExperimentEnrollment};
+    use tempdir::TempDir;
+
+    #[test]
+    fn test_telemetry_reset() -> Result<()> {
+        let mock_client_id = "client-1".to_string();
+        let mock_exp_slug = "exp-1".to_string();
+        let mock_exp_branch = "branch-1".to_string();
+
+        let tmp_dir = TempDir::new("test_telemetry_reset")?;
+        let mut client = NimbusClient::new(
+            AppContext::default(),
+            tmp_dir.path(),
+            None,
+            AvailableRandomizationUnits {
+                client_id: Some(mock_client_id.clone()),
+                ..AvailableRandomizationUnits::default()
+            },
+        )?;
+
+        // Mock being enrolled in a single experiment.
+        let db = client.db()?;
+        let mut writer = db.write()?;
+        db.get_store(StoreId::Experiments).put(
+            &mut writer,
+            &mock_exp_slug,
+            &Experiment {
+                slug: mock_exp_slug.clone(),
+                ..Experiment::default()
+            },
+        )?;
+        db.get_store(StoreId::Enrollments).put(
+            &mut writer,
+            &mock_exp_slug,
+            &ExperimentEnrollment {
+                slug: mock_exp_slug.clone(),
+                status: EnrollmentStatus::new_enrolled(EnrolledReason::Qualified, &mock_exp_branch),
+            },
+        )?;
+        writer.commit()?;
+
+        // Check expected state before resetting telemetry.
+        let orig_nimbus_id = client.nimbus_id()?;
+        assert_eq!(
+            client.available_randomization_units.client_id,
+            Some(mock_client_id)
+        );
+        assert_eq!(
+            client.get_experiment_branch(mock_exp_slug.clone())?,
+            Some(mock_exp_branch)
+        );
+
+        let events = client.reset_telemetry_identifiers(AvailableRandomizationUnits::default())?;
+
+        // We should have reset our nimbus_id.
+        assert_ne!(orig_nimbus_id, client.nimbus_id()?);
+
+        // We should have updated the randomization units.
+        assert_eq!(client.available_randomization_units.client_id, None);
+
+        // We should have been disqualified from the enrolled experiment.
+        assert_eq!(client.get_experiment_branch(mock_exp_slug)?, None);
+
+        // We should have returned a single event.
+        assert_eq!(events.len(), 1);
+
+        Ok(())
+    }
+}

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -139,4 +139,21 @@ interface NimbusClient {
     // Opt out of a specific experiment.
     [Throws=Error]
     sequence<EnrollmentChangeEvent> opt_out(string experiment_slug);
+
+    // Reset internal state in response to application-level telemetry reset.
+    //
+    // Consumers should call this method when the user resets the telemetry state of the
+    // consuming application, such as by opting out of submitting telemetry. It resets the
+    // internal state of the Nimbus client to create a clean break between data collected
+    // before and after the reset, including:
+    //
+    //    * clearing any unique identifiers used internally, so they will reset to
+    //      new random values on next use.
+    //    * accepting new randomization units, based on application-level ids that
+    //      may have also changed.
+    //    * disqualifying this client out of any active experiments, to avoid submitting
+    //      misleading incomplete data.
+    //
+    [Throws=Error]
+    sequence<EnrollmentChangeEvent> reset_telemetry_identifiers(AvailableRandomizationUnits new_randomization_units);
 };


### PR DESCRIPTION
Fixes [SDK-136](https://jira.mozilla.com/browse/SDK-136).

When the user disables telemetry in the consuming application, we need
to reset any unique identifiers used internally by the SDK. This guards
against accidentally correlating metrics submitted before the opt-out
with metrics that the user may opt-in to submitting again in future.

Consumers are expected to call `on_telemetry_disabled` when the user
disables telemetry in order to trigger resetting of the identifiers.

This needs tests before it's ready for review, but I wanted to push it early for feedback in light of https://github.com/mozilla/nimbus-sdk/pull/78. IIUC, the work in https://github.com/mozilla/nimbus-sdk/pull/78 is based on the notion that we should not change experiment enrollment state as an incidental side-effect of other operations in the SDK, because doing so could cause weird UX changes or inconsistencies in the app. Similarly, I think it would be weird for the user to click "disable telemetry" and then suddenly some unrelated part of the application UX changes.

~~So, what I've done here is add an `on_telemetry_disabled` method which resets the unique identifiers used by the SDK, but *leaves their existing enrollments intact*.~~

~~I think it would be reasonable to wipe any existing enrollments in the next call to `apply_pending_updates`, but we should defer that until after #78 lands so we can re-use its "pending update" infrastructure.~~

[**UPDATE:** the approach in this PR has changed a bit, see comments below for details]

@travis79 @mhammond @jhugman thoughts?