### PR TITLE
Add enrollment_id to the `EnrolledExperiment` struct

### DIFF
--- a/nimbus/src/enrollment.rs
+++ b/nimbus/src/enrollment.rs
@@ -441,7 +441,12 @@ pub fn get_enrollments(db: &Database) -> Result<Vec<EnrolledExperiment>> {
     let mut result = Vec::with_capacity(enrollments.len());
     for enrollment in enrollments {
         log::debug!("Have enrollment: {:?}", enrollment);
-        if let EnrollmentStatus::Enrolled { branch, .. } = &enrollment.status {
+        if let EnrollmentStatus::Enrolled {
+            branch,
+            enrollment_id,
+            ..
+        } = &enrollment.status
+        {
             if let Some(experiment) =
                 db.get::<Experiment>(StoreId::Experiments, &enrollment.slug)?
             {
@@ -450,6 +455,7 @@ pub fn get_enrollments(db: &Database) -> Result<Vec<EnrolledExperiment>> {
                     user_facing_name: experiment.user_facing_name,
                     user_facing_description: experiment.user_facing_description,
                     branch_slug: branch.to_string(),
+                    enrollment_id: enrollment_id.to_string(),
                 });
             } else {
                 log::warn!(

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -176,6 +176,7 @@ pub struct EnrolledExperiment {
     pub user_facing_name: String,
     pub user_facing_description: String,
     pub branch_slug: String,
+    pub enrollment_id: String,
 }
 
 /// This is the currently supported major schema version.

--- a/nimbus/src/nimbus.idl
+++ b/nimbus/src/nimbus.idl
@@ -18,6 +18,7 @@ dictionary EnrolledExperiment {
     string user_facing_name;
     string user_facing_description;
     string branch_slug;
+    string enrollment_id;
 };
 
 dictionary RemoteSettingsConfig {


### PR DESCRIPTION
In order to have access to the enrollment_id for the purpose of emitting the exposure event from the Android-Component layer, we need to add it to the EnrolledExperiment struct as a string, which already gets passed across the FFI and is available through the get_active_experiments() function.