### PR TITLE
[SDK-159] Fix experiment example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ captures
 
 *.jar
 !android/gradle/wrapper/gradle-wrapper.jar
+
+nimbus/db/

--- a/nimbus/examples/config/config.json
+++ b/nimbus/examples/config/config.json
@@ -1,5 +1,5 @@
 {
-    "context": {"app_id": "fenix", "locale": "en-US"},
+    "context": {"app_id": "org.mozilla.fenix", "locale": "en-US"},
     "collection_name": "nimbus-mobile-experiments",
     "client_id": "{2204ac0e-1428-11eb-adc1-0242ac120002}"
 }

--- a/nimbus/examples/experiment.rs
+++ b/nimbus/examples/experiment.rs
@@ -5,12 +5,12 @@
 use clap::{App, Arg, SubCommand};
 use env_logger::Env;
 use nimbus::{
-    error::Result, AppContext, AvailableRandomizationUnits, NimbusClient, RemoteSettingsConfig,
+    error::Result, AppContext, AvailableRandomizationUnits, NimbusClient, RemoteSettingsConfig, EnrollmentStatus
 };
 use std::collections::HashMap;
 use std::io::prelude::*;
 
-const DEFAULT_BASE_URL: &str = "https://settings.stage.mozaws.net"; // TODO: Replace this with prod
+const DEFAULT_BASE_URL: &str = "https://firefox.settings.services.mozilla.com";
 const DEFAULT_BUCKET_NAME: &str = "main";
 const DEFAULT_COLLECTION_NAME: &str = "messaging-experiments";
 fn main() -> Result<()> {
@@ -204,7 +204,7 @@ fn main() -> Result<()> {
     let aru = AvailableRandomizationUnits::with_client_id(&client_id);
 
     // Here we initialize our main `NimbusClient` struct
-    let mut nimbus_client = NimbusClient::new(context, "", Some(config), aru)?;
+    let mut nimbus_client = NimbusClient::new(context.clone(), "", Some(config), aru)?;
 
     // Explicitly update experiments at least once for init purposes
     nimbus_client.fetch_experiments()?;
@@ -290,7 +290,7 @@ fn main() -> Result<()> {
                 let uuid = uuid::Uuid::new_v4();
                 let mut num_of_experiments_enrolled = 0;
                 for exp in &all_experiments {
-                    let enr = nimbus::evaluate_enrollment(&uuid, &aru, &Default::default(), &exp)?;
+                    let enr = nimbus::evaluate_enrollment(&uuid, &aru, &context.clone(), &exp)?;
                     if enr.status.is_enrolled() {
                         num_of_experiments_enrolled += 1;
                         if num_of_experiments_enrolled >= num {
@@ -345,10 +345,17 @@ fn main() -> Result<()> {
                 let uuid = uuid::Uuid::new_v4();
                 let aru = AvailableRandomizationUnits::with_client_id(&client_id);
                 let enrollment =
-                    nimbus::evaluate_enrollment(&uuid, &aru, &Default::default(), &exp)?;
+                    nimbus::evaluate_enrollment(&uuid, &aru, &context.clone(), &exp)?;
+                let key = match enrollment.status.clone() {
+                    EnrollmentStatus::Enrolled { .. } => "Enrolled",
+                    EnrollmentStatus::NotEnrolled { .. } => "NotEnrolled",
+                    EnrollmentStatus::Disqualified { .. } => "Disqualified",
+                    EnrollmentStatus::WasEnrolled { .. } => "WasEnrolled",
+                    EnrollmentStatus::Error { .. } => "Error",
+                };
                 results.insert(
-                    enrollment.status.clone(),
-                    results.get(&enrollment.status).unwrap_or(&0) + 1,
+                    key.clone(),
+                    results.get(&key).unwrap_or(&0) + 1,
                 );
             }
             println!("Results: {:#?}", results);

--- a/nimbus/examples/experiment.rs
+++ b/nimbus/examples/experiment.rs
@@ -353,7 +353,7 @@ fn main() -> Result<()> {
                     EnrollmentStatus::WasEnrolled { .. } => "WasEnrolled",
                     EnrollmentStatus::Error { .. } => "Error",
                 };
-                results.insert(key.clone(), results.get(&key).unwrap_or(&0) + 1);
+                results.insert(key, results.get(&key).unwrap_or(&0) + 1);
             }
             println!("Results: {:#?}", results);
         }

--- a/nimbus/examples/experiment.rs
+++ b/nimbus/examples/experiment.rs
@@ -5,7 +5,8 @@
 use clap::{App, Arg, SubCommand};
 use env_logger::Env;
 use nimbus::{
-    error::Result, AppContext, AvailableRandomizationUnits, NimbusClient, RemoteSettingsConfig, EnrollmentStatus
+    error::Result, AppContext, AvailableRandomizationUnits, EnrollmentStatus, NimbusClient,
+    RemoteSettingsConfig,
 };
 use std::collections::HashMap;
 use std::io::prelude::*;
@@ -344,8 +345,7 @@ fn main() -> Result<()> {
                 // options.
                 let uuid = uuid::Uuid::new_v4();
                 let aru = AvailableRandomizationUnits::with_client_id(&client_id);
-                let enrollment =
-                    nimbus::evaluate_enrollment(&uuid, &aru, &context.clone(), &exp)?;
+                let enrollment = nimbus::evaluate_enrollment(&uuid, &aru, &context.clone(), &exp)?;
                 let key = match enrollment.status.clone() {
                     EnrollmentStatus::Enrolled { .. } => "Enrolled",
                     EnrollmentStatus::NotEnrolled { .. } => "NotEnrolled",
@@ -353,10 +353,7 @@ fn main() -> Result<()> {
                     EnrollmentStatus::WasEnrolled { .. } => "WasEnrolled",
                     EnrollmentStatus::Error { .. } => "Error",
                 };
-                results.insert(
-                    key.clone(),
-                    results.get(&key).unwrap_or(&0) + 1,
-                );
+                results.insert(key.clone(), results.get(&key).unwrap_or(&0) + 1);
             }
             println!("Results: {:#?}", results);
         }

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -23,6 +23,7 @@ use enrollment::{
     EnrollmentsEvolver,
 };
 pub use matcher::AppContext;
+pub use enrollment::EnrollmentStatus;
 use once_cell::sync::OnceCell;
 use persistence::{Database, StoreId};
 use serde_derive::*;

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -17,13 +17,13 @@ pub use evaluator::evaluate_enrollment;
 
 use client::{create_client, parse_experiments, SettingsClient};
 pub use config::RemoteSettingsConfig;
+pub use enrollment::EnrollmentStatus;
 use enrollment::{
     get_enrollments, get_global_user_participation, opt_in_with_branch, opt_out,
     set_global_user_participation, EnrollmentChangeEvent, EnrollmentChangeEventType,
     EnrollmentsEvolver,
 };
 pub use matcher::AppContext;
-pub use enrollment::EnrollmentStatus;
 use once_cell::sync::OnceCell;
 use persistence::{Database, StoreId};
 use serde_derive::*;


### PR DESCRIPTION
This fixes the experiment CLI example, specifically the `gen-uuid` and `brute-force` commands which didn't quite work after the updates to the `EnrollmentStatus` which added the `enrollment_id`.