### PR TITLE
Delete the database if opening it fails with an error indicating it is invalid or corrupt

### DIFF
--- a/nimbus/src/client/http_client.rs
+++ b/nimbus/src/client/http_client.rs
@@ -236,6 +236,13 @@ mod tests {
                     "ratio": 1
                     }}
                 ]
+            }},
+            {{
+                "slug": "schema-version-missing",
+                "application": "reference-browser",
+                "userFacingName": "Schema Version Missing",
+                "userFacingDescription": "This should be completely ignored",
+                "isEnrollmentPaused": false
             }}
         ]}}"#,
             current_version = SCHEMA_VERSION,


### PR DESCRIPTION
There are 2 RKV errors that seem to indicate a clearly invalid DB (and [SDK-163](https://jira.mozilla.com/browse/SDK-163) hits one of them.) On these errors we delete the entire `db` directory then recreate it and recreate the DB. This seems a little scary, but the only other alternative is to have a set of files we know to delete, but that seems fragile - there might be other rkv files that only exist in edge-cases (or in future versions) and leaving them behind might cause further problems.

There's a bonus commit which adds an experiment without a schema-version to some tests, but as expected, this is handled correctly. I didn't think it was worth its own PR, but also didn't want to discard it.