### PR TITLE
Merge v0.7.2 to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased changes
+
+# 0.7.0 (_2021-01-28_)
 ## What's New
  - Split up `NimbusClient.update_experiments()` into a slow `NimbusClient.fetch_experiments()` and a fast `NimbusClient.apply_pending_experiments()` to help apps manage concurrency and mutable state.
  - Add `set_local_experiments(string)`, to help apps, build tooling for tests, and help during startup on first time run.
+ - `get_experiment_branch()` no longer performs any IO, nor blocks on any other threads that may be performing IO, making it suitable for being called from the main-thread of apps.
 
 ## ⚠️ Breaking changes ⚠️
  - `NimbusClient.updateExperiments()` is removed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased changes
 
+# 0.7.1 (_2021-01-28_)
+## What's New
+ - Avoid the use of unsigned "experimental" kotlin types.
+
 # 0.7.0 (_2021-01-28_)
 ## What's New
  - Split up `NimbusClient.update_experiments()` into a slow `NimbusClient.fetch_experiments()` and a fast `NimbusClient.apply_pending_experiments()` to help apps manage concurrency and mutable state.

--- a/nimbus/Cargo.lock
+++ b/nimbus/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "nimbus-sdk"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/nimbus/Cargo.lock
+++ b/nimbus/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "nimbus-sdk"
-version = "0.6.4"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/nimbus/Cargo.lock
+++ b/nimbus/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "nimbus-sdk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/nimbus/Cargo.toml
+++ b/nimbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nimbus-sdk"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["The Glean Team <glean-team@mozilla.com>", "The Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 description = "A rapid experiment library"

--- a/nimbus/Cargo.toml
+++ b/nimbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nimbus-sdk"
-version = "0.6.4"
+version = "0.7.0"
 authors = ["The Glean Team <glean-team@mozilla.com>", "The Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 description = "A rapid experiment library"

--- a/nimbus/Cargo.toml
+++ b/nimbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nimbus-sdk"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["The Glean Team <glean-team@mozilla.com>", "The Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 description = "A rapid experiment library"


### PR DESCRIPTION
This release makes the new `reset_telemetry_identifiers` method available to considers.

This seems to want to merge the release commits from previous `v0.7.x` releases into main as well, although the changelog entries etc are already there. I guess maybe we did a rebase-merge to get them onto `main` rather than creating a merge commit? Anyway, I did a merge commit to try to sync things up.