### PR TITLE
Make featureIds optional to keep bookmarks A/B working (SDK-190)

### DIFF
--- a/nimbus/tests/common/mod.rs
+++ b/nimbus/tests/common/mod.rs
@@ -118,7 +118,42 @@ pub fn initial_test_experiments() -> String {
                 "userFacingDescription":"This is a test experiment for diagnostic purposes.",
                 "id":"secure-gold",
                 "last_modified":1_602_197_324_372i64
+            },
+            {
+                "schemaVersion": "1.0.0",
+                "slug": "no-features",
+                "endDate": null,
+                "branches":[
+                    {
+                        "slug": "control",
+                        "ratio": 1,
+                    },
+                    {
+                        "slug": "treatment",
+                        "ratio": 1,
+                    }
+                ],
+                "probeSets":[],
+                "startDate":null,
+                "application":"fenix",
+                "bucketConfig":{
+                    // Setup to enroll everyone by default.
+                    "count":10_000,
+                    "start":0,
+                    "total":10_000,
+                    "namespace":"secure-gold",
+                    "randomizationUnit":"nimbus_id"
+                },
+                "userFacingName":"Diagnostic test experiment",
+                "referenceBranch":"control",
+                "isEnrollmentPaused":false,
+                "proposedEnrollment":7,
+                "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+                "id":"no-features",
+                "last_modified":1_602_197_324_372i64
             }
+
+
         ]
     })
     .to_string()


### PR DESCRIPTION
Here are the beginnings of what we need.  So far I've got same enrollment tests running on both a feature with featureIds and one without.  The second set is (correctly, if I've done it right) failing.

Next steps are:

   * find an excited volunteer to drive this forward!  Perhaps @travis79 or @jhugman?  I've invited you both as collabators on my fork, where this branch lives...
   * hack on the code until those tests pass
   * write remaining tests so that all the acceptance criteria in [SDK-190](https://jira.mozilla.com/browse/SDK-190) are covered
   * make those tests pass
   * review & land
