### PR TITLE
Add test to prove experiments without a feature_ids field work

### DIFF
--- a/nimbus/src/enrollment.rs
+++ b/nimbus/src/enrollment.rs
@@ -916,7 +916,10 @@ mod tests {
         let enrollment = evolver
             .evolve_enrollment(true, None, Some(exp), None, &mut events)?
             .unwrap();
-        assert!(matches!(enrollment.status, EnrollmentStatus::Enrolled { .. }));
+        assert!(matches!(
+            enrollment.status,
+            EnrollmentStatus::Enrolled { .. }
+        ));
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].experiment_slug, exp.slug);
         assert_eq!(events[0].change, EnrollmentChangeEventType::Enrollment);
@@ -1089,7 +1092,11 @@ mod tests {
             )?
             .unwrap();
         assert!(matches!(
-            enrollment.status, EnrollmentStatus::Enrolled {reason: EnrolledReason::Qualified, .. }
+            enrollment.status,
+            EnrollmentStatus::Enrolled {
+                reason: EnrolledReason::Qualified,
+                ..
+            }
         ));
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].experiment_slug, exp.slug);
@@ -1122,9 +1129,13 @@ mod tests {
                 &mut events,
             )?
             .unwrap();
-        assert!(
-            matches!(enrollment.status, EnrollmentStatus::Disqualified { reason: DisqualifiedReason::OptOut, .. })
-        );
+        assert!(matches!(
+            enrollment.status,
+            EnrollmentStatus::Disqualified {
+                reason: DisqualifiedReason::OptOut,
+                ..
+            }
+        ));
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].enrollment_id, enrollment_id.to_string());
         assert_eq!(events[0].experiment_slug, exp.slug);
@@ -1736,9 +1747,13 @@ mod tests {
             },
         };
         let enrollment = existing_enrollment.on_explicit_opt_out(&mut events)?;
-        assert!(
-            matches!(enrollment.status, EnrollmentStatus::NotEnrolled { reason: NotEnrolledReason::OptOut, .. })
-        );
+        assert!(matches!(
+            enrollment.status,
+            EnrollmentStatus::NotEnrolled {
+                reason: NotEnrolledReason::OptOut,
+                ..
+            }
+        ));
         assert!(events.is_empty());
         Ok(())
     }
@@ -1807,9 +1822,13 @@ mod tests {
             .get_store(StoreId::Enrollments)
             .get(&writer, "secure-gold")?
             .expect("should exist");
-        assert!(
-            matches!(ee.status, EnrollmentStatus::Enrolled { reason: EnrolledReason::Qualified, .. })
-        );
+        assert!(matches!(
+            ee.status,
+            EnrollmentStatus::Enrolled {
+                reason: EnrolledReason::Qualified,
+                ..
+            }
+        ));
 
         // Now opt-out.
         opt_out(&db, &mut writer, "secure-gold")?;
@@ -1819,9 +1838,13 @@ mod tests {
             .get_store(StoreId::Enrollments)
             .get(&writer, "secure-gold")?
             .expect("should exist");
-        assert!(
-            matches!(ee.status, EnrollmentStatus::Disqualified { reason: DisqualifiedReason::OptOut,.. })
-        );
+        assert!(matches!(
+            ee.status,
+            EnrollmentStatus::Disqualified {
+                reason: DisqualifiedReason::OptOut,
+                ..
+            }
+        ));
 
         // Opt in to a specific branch.
         opt_in_with_branch(&db, &mut writer, "secure-gold", "treatment")?;
@@ -1954,7 +1977,8 @@ mod tests {
                     matches!(
                         enr.status,
                         EnrollmentStatus::Disqualified {
-                            reason: DisqualifiedReason::OptOut, ..
+                            reason: DisqualifiedReason::OptOut,
+                            ..
                         }
                     )
                 })
@@ -1977,7 +2001,8 @@ mod tests {
                     matches!(
                         enr.status,
                         EnrollmentStatus::Disqualified {
-                            reason: DisqualifiedReason::OptOut, ..
+                            reason: DisqualifiedReason::OptOut,
+                            ..
                         }
                     )
                 })
@@ -2070,12 +2095,13 @@ mod tests {
 
         // The not-enrolled experiment should have been unchanged.
         assert_eq!(enrollments[2].slug, mock_exp3_slug);
-        assert!(
-            matches!(&enrollments[2].status, EnrollmentStatus::NotEnrolled {
+        assert!(matches!(
+            &enrollments[2].status,
+            EnrollmentStatus::NotEnrolled {
                 reason: NotEnrolledReason::NotTargeted,
                 ..
-            })
-        );
+            }
+        ));
 
         // We should have returned a single disqualification event.
         assert_eq!(events.len(), 1);

--- a/nimbus/src/enrollment.rs
+++ b/nimbus/src/enrollment.rs
@@ -113,7 +113,7 @@ impl ExperimentEnrollment {
             status: EnrollmentStatus::new_enrolled(
                 EnrolledReason::OptIn,
                 branch_slug,
-                &experiment.feature_ids[0],
+                &experiment.get_first_feature_id(),
             ),
         };
         out_enrollment_events.push(enrollment.get_change_event());

--- a/nimbus/src/enrollment.rs
+++ b/nimbus/src/enrollment.rs
@@ -267,6 +267,7 @@ impl ExperimentEnrollment {
     }
 
     /// Force unenroll ourselves from an experiment.
+    #[allow(clippy::unnecessary_wraps)]
     fn on_explicit_opt_out(
         &self,
         out_enrollment_events: &mut Vec<EnrollmentChangeEvent>,

--- a/nimbus/src/evaluator.rs
+++ b/nimbus/src/evaluator.rs
@@ -373,9 +373,13 @@ mod tests {
         let enrollment =
             evaluate_enrollment(&id, &available_randomization_units, &context, &experiment1)
                 .unwrap();
-        assert!(
-            matches!(enrollment.status, EnrollmentStatus::Enrolled { reason: EnrolledReason::Qualified, .. })
-        );
+        assert!(matches!(
+            enrollment.status,
+            EnrollmentStatus::Enrolled {
+                reason: EnrolledReason::Qualified,
+                ..
+            }
+        ));
 
         let enrollment =
             evaluate_enrollment(&id, &available_randomization_units, &context, &experiment2)
@@ -400,8 +404,12 @@ mod tests {
         let enrollment =
             evaluate_enrollment(&id, &available_randomization_units, &context, &experiment2)
                 .unwrap();
-        assert!(
-            matches!(enrollment.status, EnrollmentStatus::Enrolled { reason: EnrolledReason::Qualified, .. })
-        );
+        assert!(matches!(
+            enrollment.status,
+            EnrollmentStatus::Enrolled {
+                reason: EnrolledReason::Qualified,
+                ..
+            }
+        ));
     }
 }

--- a/nimbus/src/evaluator.rs
+++ b/nimbus/src/evaluator.rs
@@ -85,7 +85,7 @@ pub fn evaluate_enrollment(
                         EnrollmentStatus::new_enrolled(
                             EnrolledReason::Qualified,
                             &choose_branch(&exp.slug, &exp.branches, &id)?.clone().slug,
-                            &exp.feature_ids[0],
+                            &exp.get_first_feature_id(),
                         )
                     } else {
                         EnrollmentStatus::NotEnrolled {

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -319,6 +319,7 @@ pub struct Experiment {
     pub bucket_config: BucketConfig,
     pub probe_sets: Vec<String>,
     pub branches: Vec<Branch>,
+    #[serde(default)]
     pub feature_ids: Vec<String>,
     pub targeting: Option<String>,
     pub start_date: Option<String>, // TODO: Use a date format here
@@ -335,6 +336,14 @@ impl Experiment {
         self.branches
             .iter()
             .any(|branch| branch.slug == branch_slug)
+    }
+
+    fn get_first_feature_id(&self) -> String {
+        if self.feature_ids.is_empty() {
+            "".to_string()
+        } else {
+            self.feature_ids[0].clone()
+        }
     }
 }
 

--- a/nimbus/tests/common/mod.rs
+++ b/nimbus/tests/common/mod.rs
@@ -30,6 +30,101 @@ pub fn new_test_client(identifier: &str) -> Result<NimbusClient> {
 }
 
 #[allow(dead_code)] // not clear why this is necessary...
+pub fn exactly_two_experiments() -> String {
+    use serde_json::json;
+    json!({
+        "data": [
+            {
+                "schemaVersion": "1.0.0",
+                "slug": "startup-gold",
+                "endDate": null,
+                "featureIds": ["aboutmonkeys"],
+                "branches":[
+                    {
+                        "slug": "control",
+                        "ratio": 1,
+                        "feature": {
+                            "featureId": "aboutmonkeys",
+                            "enabled": false
+                        }
+                    },
+                    {
+                        "slug": "treatment",
+                        "ratio":1,
+                        "feature": {
+                            "featureId": "aboutmonkeys",
+                            "enabled": true
+                        },
+
+                    }
+                ],
+                "probeSets":[],
+                "startDate":null,
+                "application":"fenix",
+                "bucketConfig":{
+                    // Setup to enroll everyone by default.
+                    "count":10_000,
+                    "start":0,
+                    "total":10_000,
+                    "namespace":"startup-gold",
+                    "randomizationUnit":"nimbus_id"
+                },
+                "userFacingName":"Diagnostic test experiment",
+                "referenceBranch":"control",
+                "isEnrollmentPaused":false,
+                "proposedEnrollment":7,
+                "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+                "id":"startup-gold",
+                "last_modified":1_602_197_324_372i64
+            },
+            {
+                "schemaVersion": "1.0.0",
+                "slug": "secure-gold",
+                "endDate": null,
+                "featureIds": ["aboutwelcome"],
+                "branches":[
+                    {
+                        "slug": "control",
+                        "ratio": 1,
+                        "feature": {
+                            "featureId": "aboutwelcome",
+                            "enabled": false
+                        },
+                    },
+                    {
+                        "slug": "treatment",
+                        "ratio":1,
+                        "feature": {
+                            "featureId": "aboutwelcome",
+                            "enabled": true
+                        },
+                    }
+                ],
+                "probeSets":[],
+                "startDate":null,
+                "application":"fenix",
+                "bucketConfig":{
+                    // Setup to enroll everyone by default.
+                    "count":10_000,
+                    "start":0,
+                    "total":10_000,
+                    "namespace":"secure-gold",
+                    "randomizationUnit":"nimbus_id"
+                },
+                "userFacingName":"Diagnostic test experiment",
+                "referenceBranch":"control",
+                "isEnrollmentPaused":false,
+                "proposedEnrollment":7,
+                "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+                "id":"secure-gold",
+                "last_modified":1_602_197_324_372i64
+            }
+        ]
+    })
+    .to_string()
+}
+
+#[allow(dead_code)] // not clear why this is necessary...
 pub fn initial_test_experiments() -> String {
     use serde_json::json;
     json!({
@@ -152,8 +247,6 @@ pub fn initial_test_experiments() -> String {
                 "id":"no-features",
                 "last_modified":1_602_197_324_372i64
             }
-
-
         ]
     })
     .to_string()

--- a/nimbus/tests/common/mod.rs
+++ b/nimbus/tests/common/mod.rs
@@ -125,7 +125,7 @@ pub fn exactly_two_experiments() -> String {
 }
 
 #[allow(dead_code)] // not clear why this is necessary...
-pub fn initial_test_experiments() -> String {
+pub fn experiments_testing_feature_ids() -> String {
     use serde_json::json;
     json!({
         "data": [

--- a/nimbus/tests/common/mod.rs
+++ b/nimbus/tests/common/mod.rs
@@ -118,7 +118,42 @@ pub fn initial_test_experiments() -> String {
                 "userFacingDescription":"This is a test experiment for diagnostic purposes.",
                 "id":"secure-gold",
                 "last_modified":1_602_197_324_372i64
+            },
+            {
+                "schemaVersion": "1.0.0",
+                "slug": "no-features",
+                "endDate": null,
+                "branches":[
+                    {
+                        "slug": "control",
+                        "ratio": 1,
+                    },
+                    {
+                        "slug": "treatment",
+                        "ratio": 1,
+                    }
+                ],
+                "probeSets":[],
+                "startDate":null,
+                "application":"fenix",
+                "bucketConfig":{
+                    // Setup to enroll everyone by default.
+                    "count":10_000,
+                    "start":0,
+                    "total":10_000,
+                    "namespace":"secure-gold",
+                    "randomizationUnit":"nimbus_id"
+                },
+                "userFacingName":"Diagnostic test experiment",
+                "referenceBranch":"control",
+                "isEnrollmentPaused":false,
+                "proposedEnrollment":7,
+                "userFacingDescription":"This is a test experiment for diagnostic purposes.",
+                "id":"no-features",
+                "last_modified":1_602_197_324_372i64
             }
+
+
         ]
     })
     .to_string()

--- a/nimbus/tests/test_get_experiment_branch_by_feature.rs
+++ b/nimbus/tests/test_get_experiment_branch_by_feature.rs
@@ -31,7 +31,7 @@ fn test_enrolled_feature() -> Result<()> {
     let _ = env_logger::try_init();
     let client = common::new_test_client("test_enrolled_feature")?;
     client.initialize()?;
-    client.set_experiments_locally(common::initial_test_experiments())?;
+    client.set_experiments_locally(common::experiments_testing_feature_ids())?;
 
     // haven't applied them yet, so not enrolled as the experiment doesn't
     // really exist.

--- a/nimbus/tests/test_get_experiment_branch_by_id.rs
+++ b/nimbus/tests/test_get_experiment_branch_by_id.rs
@@ -26,13 +26,12 @@ fn test_before_open() -> Result<()> {
 #[test]
 fn test_enrolled() -> Result<()> {
     let _ = env_logger::try_init();
-    let client = common::new_test_client("test_before_open")?;
+    let client = common::new_test_client("test_enrolled")?;
     client.initialize()?;
     client.set_experiments_locally(common::initial_test_experiments())?;
 
     let experiment_slugs = vec!["secure-gold", "no-features"];
-    for experiment_slug in experiment_slugs {
-
+    for experiment_slug in &experiment_slugs {
         // haven't applied them yet, so not enrolled as the experiment doesn't
         // really exist.
         assert_eq!(
@@ -40,13 +39,15 @@ fn test_enrolled() -> Result<()> {
             None,
             "shouldn't return anything before pending experiments applied"
         );
+    }
 
-        client.apply_pending_experiments()?;
-
+    client.apply_pending_experiments()?;
+    for experiment_slug in &experiment_slugs {
         // these experiements enroll everyone - not clear what treatment though.
-        assert!(client
-            .get_experiment_branch(experiment_slug.to_string())?
-            .is_some(),
+        assert!(
+            client
+                .get_experiment_branch(experiment_slug.to_string())?
+                .is_some(),
             "{} should return a branch for an experiment that enrolls everyone",
             experiment_slug
         );
@@ -74,14 +75,14 @@ fn test_enrolled() -> Result<()> {
             "{} should return a second branch we've just opted into",
             experiment_slug
         );
-
-        client.set_global_user_participation(false)?;
+    }
+    client.set_global_user_participation(false)?;
+    for experiment_slug in experiment_slugs {
         assert_eq!(
             client.get_experiment_branch(experiment_slug.to_string())?,
             None,
             "{} should not return a branch if we've globally opted out",
             experiment_slug
-
         );
     }
 

--- a/nimbus/tests/test_get_experiment_branch_by_id.rs
+++ b/nimbus/tests/test_get_experiment_branch_by_id.rs
@@ -28,7 +28,7 @@ fn test_enrolled() -> Result<()> {
     let _ = env_logger::try_init();
     let client = common::new_test_client("test_enrolled")?;
     client.initialize()?;
-    client.set_experiments_locally(common::initial_test_experiments())?;
+    client.set_experiments_locally(common::experiments_testing_feature_ids())?;
 
     let experiment_slugs = vec!["secure-gold", "no-features"];
     for experiment_slug in &experiment_slugs {

--- a/nimbus/tests/test_updates.rs
+++ b/nimbus/tests/test_updates.rs
@@ -11,13 +11,13 @@ mod common;
 #[cfg(feature = "rkv-safe-mode")]
 #[cfg(test)]
 mod test {
-    use super::common::{initial_test_experiments, new_test_client, no_test_experiments};
+    use super::common::{exactly_two_experiments, new_test_client, no_test_experiments};
     #[cfg(feature = "rkv-safe-mode")]
     use nimbus::{error::Result, NimbusClient};
 
     fn startup(client: &NimbusClient, first_run: bool) -> Result<()> {
         if first_run {
-            client.set_experiments_locally(initial_test_experiments())?;
+            client.set_experiments_locally(exactly_two_experiments())?;
         }
         client.apply_pending_experiments()?;
         client.fetch_experiments()?;
@@ -68,7 +68,7 @@ mod test {
         let client = new_test_client("test_set_experiments_locally")?;
         assert_experiment_count(&client, 0)?;
 
-        client.set_experiments_locally(initial_test_experiments())?;
+        client.set_experiments_locally(exactly_two_experiments())?;
         assert_experiment_count(&client, 0)?;
 
         client.apply_pending_experiments()?;


### PR DESCRIPTION
This PR replaces #100, and fixes SDK-190.

Not long ago, experimenter was producing experiment JSON without an array for `feature_ids`.

Unfortunately, some of these experiments are still live. The experiments were not being parsed,
and mass enrollments happened.

Going forward, `feature_ids` should be a required field.

This PR defaults `feature_ids` when missing to an empty vec of strings. For parts of the code that require a `featue_id`, an empty string is used. This will need to be revisited once we actually support multiple features per branch.