### PR TITLE
Update rkv to 0.17.0

### DIFF
--- a/nimbus/Cargo.lock
+++ b/nimbus/Cargo.lock
@@ -307,27 +307,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "ffi-support"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,15 +1311,14 @@ dependencies = [
 
 [[package]]
 name = "rkv"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97d1b6321740ce36d77d67d22ff84ac8a996cf69dbd0727b8bcae52f1c98aaa"
+checksum = "28e2e15d3fff125cfc4fb3f1b226ff83af057c4715061ded16193b7142beefc9"
 dependencies = [
  "arrayref",
  "bincode",
  "bitflags",
  "byteorder",
- "failure",
  "id-arena",
  "lazy_static",
  "lmdb-rkv",
@@ -1349,6 +1327,7 @@ dependencies = [
  "paste 0.1.18",
  "serde",
  "serde_derive",
+ "thiserror",
  "url",
  "uuid",
 ]
@@ -1514,18 +1493,6 @@ checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
  "unicode-xid",
 ]
 

--- a/nimbus/Cargo.toml
+++ b/nimbus/Cargo.toml
@@ -29,7 +29,7 @@ log = "0.4"
 viaduct = { git = "https://github.com/mozilla/application-services", rev = "8a576fbe79199fa8664f64285524017f74ebcc5f"}
 thiserror = "1"
 url = "2.1"
-rkv = "0.15"
+rkv = "0.17"
 jexl-eval = "0.1.7"
 uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"

--- a/nimbus/src/error.rs
+++ b/nimbus/src/error.rs
@@ -12,7 +12,7 @@ pub enum Error {
     #[error("Invalid persisted data")]
     InvalidPersistedData,
     #[error("Rkv error: {0}")]
-    RkvError(rkv::StoreError),
+    RkvError(#[from] rkv::StoreError),
     #[error("IO error: {0}")]
     IOError(#[from] std::io::Error),
     #[error("JSON Error: {0}")]
@@ -51,14 +51,6 @@ pub enum Error {
     BackoffError(u64),
     #[error("Initialization of the database is not yet complete")]
     DatabaseNotReady,
-}
-
-// This can be replaced with #[from] in the enum definition
-// once rkv::StoreError impl std::error:Error (https://github.com/mozilla/rkv/issues/188)
-impl From<rkv::StoreError> for Error {
-    fn from(store_error: rkv::StoreError) -> Self {
-        Error::RkvError(store_error)
-    }
 }
 
 impl<'a> From<jexl_eval::error::EvaluationError<'a>> for Error {


### PR DESCRIPTION
We were debating whether to upgrade rkv before the next release and I'm leaning towards that we should for the following reasons:

* [glean is on it](https://github.com/mozilla/glean/commit/4a3443f594) as is [mozilla-central is on it](https://searchfox.org/mozilla-central/rev/5120ec68572d946bd15101cf2ee2eaf4a210724f/Cargo.lock#4358) and both have been for weeks now.
* It removes a dependency - rkv now uses `thiserror` which is the same error package we use. This also means we can remove some boilerplate in our error.rs
