### PR TITLE
Release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unreleased changes
 
+# 0.8.1 (_2021-02-17_)
+
+## What's New
+
+- Defaulting `feature_id` and `feature_ids` to the empty string, to allow migration from existing
+experiment formats to continue to work.
+
 # 0.8.0 (_2021-02-11_)
 
 ## What's New

--- a/nimbus/Cargo.lock
+++ b/nimbus/Cargo.lock
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "nimbus-sdk"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/nimbus/Cargo.toml
+++ b/nimbus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nimbus-sdk"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["The Glean Team <glean-team@mozilla.com>", "The Sync Team <sync-team@mozilla.com>"]
 edition = "2018"
 description = "A rapid experiment library"


### PR DESCRIPTION
As prescribed by [release process][1].

[1]: https://github.com/mozilla/nimbus-sdk/blob/main/README.md#cutting-a-release