### PR TITLE
Upgrade uniffi to 0.8.0, for iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased changes
 
+## What's Changed
+
+- Upgraded uniffi to 0.8.0. This is to allow nimbus to be includable in the iOS megazord.
+
 # 0.8.2 (_2021-02-23_)
 
 ## What's Changed

--- a/nimbus/Cargo.toml
+++ b/nimbus/Cargo.toml
@@ -35,10 +35,10 @@ uuid = { version = "0.8", features = ["serde", "v4"]}
 sha2 = "0.9"
 hex = "0.4"
 once_cell = "1"
-uniffi = { version = "0.7", optional = true }
+uniffi = { version = "^0.8.0", optional = true }
 
 [build-dependencies]
-uniffi_build = { version = "0.7", features = [ "builtin-bindgen" ], optional = true }
+uniffi_build = { version = "^0.8.0", features = [ "builtin-bindgen" ], optional = true }
 
 [dev-dependencies]
 viaduct-reqwest = { git = "https://github.com/mozilla/application-services", rev = "8a576fbe79199fa8664f64285524017f74ebcc5f"}


### PR DESCRIPTION
As per description, in service of https://github.com/mozilla/application-services/pull/3901 .