### PR TITLE
Rename Error to NimbusError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## What's Changed
 
 - Upgraded uniffi to 0.8.0. This is to allow nimbus to be includable in the iOS megazord.
+- Changed `Error` to `NimbusError`. This is so as not collide with other implementations of Error in the megazord, (including Swift's).
 
 # 0.8.2 (_2021-02-23_)
 

--- a/nimbus/src/client/mod.rs
+++ b/nimbus/src/client/mod.rs
@@ -5,7 +5,7 @@
 mod fs_client;
 mod http_client;
 mod null_client;
-use crate::error::{Error, Result};
+use crate::error::{NimbusError, Result};
 use crate::Experiment;
 use crate::RemoteSettingsConfig;
 use fs_client::FileSystemClient;
@@ -29,7 +29,7 @@ pub(crate) fn create_client(
                 // seem valuable for the use-cases we care about here.
                 let path = match url.to_file_path() {
                     Ok(path) => path,
-                    _ => return Err(Error::InvalidPath(config.server_url)),
+                    _ => return Err(NimbusError::InvalidPath(config.server_url)),
                 };
                 Box::new(FileSystemClient::new(path)?)
             } else {

--- a/nimbus/src/dbcache.rs
+++ b/nimbus/src/dbcache.rs
@@ -3,7 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 use crate::enrollment::get_enrollments;
-use crate::error::{Error, Result};
+use crate::error::{NimbusError, Result};
 use crate::persistence::{Database, Writer};
 use std::collections::HashMap;
 use std::sync::RwLock;
@@ -91,7 +91,7 @@ impl DatabaseCache {
                 log::warn!(
                     "DatabaseCache attempting to read data before initialization is completed"
                 );
-                Err(Error::DatabaseNotReady)
+                Err(NimbusError::DatabaseNotReady)
             }
             Some(ref data) => Ok(func(data)),
         }

--- a/nimbus/src/enrollment.rs
+++ b/nimbus/src/enrollment.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 use crate::persistence::{Database, StoreId, Writer};
-use crate::{error::Result, Error};
+use crate::{error::Result, NimbusError as Error};
 use crate::{evaluator::evaluate_enrollment, persistence::Readable};
 use crate::{AppContext, AvailableRandomizationUnits, EnrolledExperiment, Experiment};
 

--- a/nimbus/src/enrollment.rs
+++ b/nimbus/src/enrollment.rs
@@ -1,8 +1,8 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use crate::error::{NimbusError, Result};
 use crate::persistence::{Database, StoreId, Writer};
-use crate::{error::Result, NimbusError as Error};
 use crate::{evaluator::evaluate_enrollment, persistence::Readable};
 use crate::{AppContext, AvailableRandomizationUnits, EnrolledExperiment, Experiment};
 
@@ -110,7 +110,7 @@ impl ExperimentEnrollment {
         out_enrollment_events: &mut Vec<EnrollmentChangeEvent>,
     ) -> Result<Self> {
         if !experiment.has_branch(branch_slug) {
-            return Err(Error::NoSuchBranch(
+            return Err(NimbusError::NoSuchBranch(
                 branch_slug.to_owned(),
                 experiment.slug.clone(),
             ));
@@ -583,7 +583,7 @@ impl<'a> EnrollmentsEvolver<'a> {
         for experiment in updated_experiments {
             // Sanity check.
             if !updated_enrollments.contains_key(&experiment.slug) {
-                return Err(Error::InternalError(
+                return Err(NimbusError::InternalError(
                     "An experiment must always have an associated enrollment.",
                 ));
             }
@@ -665,12 +665,12 @@ impl<'a> EnrollmentsEvolver<'a> {
                 }
                 (None, None, Some(enrollment)) => enrollment.maybe_garbage_collect(),
                 (None, Some(_), Some(_)) => {
-                    return Err(Error::InternalError(
+                    return Err(NimbusError::InternalError(
                         "New experiment but enrollment already exists.",
                     ))
                 }
                 (Some(_), None, None) | (Some(_), Some(_), None) => {
-                    return Err(Error::InternalError(
+                    return Err(NimbusError::InternalError(
                         "Experiment in the db did not have an associated enrollment record.",
                     ))
                 }
@@ -739,7 +739,7 @@ pub fn opt_in_with_branch(
     let exp: Experiment = db
         .get_store(StoreId::Experiments)
         .get(writer, experiment_slug)?
-        .ok_or_else(|| Error::NoSuchExperiment(experiment_slug.to_owned()))?;
+        .ok_or_else(|| NimbusError::NoSuchExperiment(experiment_slug.to_owned()))?;
     let enrollment = ExperimentEnrollment::from_explicit_opt_in(&exp, branch, &mut events)?;
     db.get_store(StoreId::Enrollments)
         .put(writer, experiment_slug, &enrollment)?;
@@ -755,7 +755,7 @@ pub fn opt_out(
     let enr_store = db.get_store(StoreId::Enrollments);
     let existing_enrollment: ExperimentEnrollment = enr_store
         .get(writer, experiment_slug)?
-        .ok_or_else(|| Error::NoSuchExperiment(experiment_slug.to_owned()))?;
+        .ok_or_else(|| NimbusError::NoSuchExperiment(experiment_slug.to_owned()))?;
     let updated_enrollment = existing_enrollment.on_explicit_opt_out(&mut events)?;
     enr_store.put(writer, experiment_slug, &updated_enrollment)?;
     Ok(events)

--- a/nimbus/src/error.rs
+++ b/nimbus/src/error.rs
@@ -8,7 +8,7 @@
 //! TODO: Implement proper error handling, this would include defining the error enum,
 //! impl std::error::Error using `thiserror` and ensuring all errors are handled appropriately
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum NimbusError {
     #[error("Invalid persisted data")]
     InvalidPersistedData,
     #[error("Rkv error: {0}")]
@@ -53,10 +53,10 @@ pub enum Error {
     DatabaseNotReady,
 }
 
-impl<'a> From<jexl_eval::error::EvaluationError<'a>> for Error {
+impl<'a> From<jexl_eval::error::EvaluationError<'a>> for NimbusError {
     fn from(eval_error: jexl_eval::error::EvaluationError<'a>) -> Self {
-        Error::EvaluationError(eval_error.to_string())
+        NimbusError::EvaluationError(eval_error.to_string())
     }
 }
 
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T, E = NimbusError> = std::result::Result<T, E>;

--- a/nimbus/src/evaluator.rs
+++ b/nimbus/src/evaluator.rs
@@ -7,7 +7,7 @@ use crate::enrollment::{
     EnrolledReason, EnrollmentStatus, ExperimentEnrollment, NotEnrolledReason,
 };
 use crate::{
-    error::{Error, Result},
+    error::{NimbusError, Result},
     AvailableRandomizationUnits,
 };
 use crate::{matcher::AppContext, sampling};
@@ -138,7 +138,7 @@ fn choose_branch<'a>(slug: &str, branches: &'a [Branch], id: &str) -> Result<&'a
     // TODO: Change it to be something more related to the SDK if it is needed
     let input = format!("{:}-{:}-{:}-branch", "experimentmanager", id, slug);
     let index = sampling::ratio_sample(&input, &ratios)?;
-    branches.get(index).ok_or(Error::OutOfBoundsError)
+    branches.get(index).ok_or(NimbusError::OutOfBoundsError)
 }
 
 /// Checks if the client is targeted by an experiment
@@ -167,11 +167,11 @@ fn targeting(expression_statement: &str, ctx: &AppContext) -> Option<EnrollmentS
                 reason: NotEnrolledReason::NotTargeted,
             }),
             None => Some(EnrollmentStatus::Error {
-                reason: Error::InvalidExpression.to_string(),
+                reason: NimbusError::InvalidExpression.to_string(),
             }),
         },
         Err(e) => Some(EnrollmentStatus::Error {
-            reason: Error::EvaluationError(e.to_string()).to_string(),
+            reason: NimbusError::EvaluationError(e.to_string()).to_string(),
         }),
     }
 }

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -6,7 +6,7 @@ mod dbcache;
 mod enrollment;
 pub mod error;
 mod evaluator;
-pub use error::{Error, Result};
+pub use error::{Error as NimbusError, Result};
 mod client;
 mod config;
 mod matcher;
@@ -102,7 +102,7 @@ impl NimbusClient {
             .iter()
             .find(|e| e.slug == slug)
             .map(|e| e.branches.clone())
-            .ok_or(Error::NoSuchExperiment(slug))?)
+            .ok_or(NimbusError::NoSuchExperiment(slug))?)
     }
 
     pub fn get_global_user_participation(&self) -> Result<bool> {

--- a/nimbus/src/lib.rs
+++ b/nimbus/src/lib.rs
@@ -6,7 +6,7 @@ mod dbcache;
 mod enrollment;
 pub mod error;
 mod evaluator;
-pub use error::{Error as NimbusError, Result};
+pub use error::{NimbusError, Result};
 mod client;
 mod config;
 mod matcher;

--- a/nimbus/src/nimbus.udl
+++ b/nimbus/src/nimbus.udl
@@ -62,7 +62,7 @@ enum EnrollmentChangeEventType {
 };
 
 [Error]
-enum Error {
+enum NimbusError {
     "InvalidPersistedData", "RkvError", "IOError",
     "JSONError", "EvaluationError", "InvalidExpression", "InvalidFraction",
     "TryFromSliceError", "EmptyRatiosError", "OutOfBoundsError","UrlParsingError",
@@ -73,7 +73,7 @@ enum Error {
 
 [Threadsafe]
 interface NimbusClient {
-    [Throws=Error]
+    [Throws=NimbusError]
     constructor(
         AppContext app_ctx,
         string dbpath,
@@ -89,7 +89,7 @@ interface NimbusClient {
     // so that the consuming application can have confidence the non-blocking
     // functions will return data instead of returning an error, and will do
     // the minimum amount of work to achieve that.
-    [Throws=Error]
+    [Throws=NimbusError]
     void initialize();
 
     // Returns the branch allocated for a given feature_id or experiment_slug.
@@ -97,50 +97,50 @@ interface NimbusClient {
     // the first hit. If the user is enrolled neither in an experiment with id
     // as the feature_id nor with id as the experiment_slug for the feature,
     // null is returned.
-    [Throws=Error]
+    [Throws=NimbusError]
     string? get_experiment_branch(string id);
 
     // Returns a list of experiment branches for a given experiment ID.
-    [Throws=Error]
+    [Throws=NimbusError]
     sequence<Branch> get_experiment_branches(string experiment_slug);
 
     // Returns a list of experiments this user is enrolled in.
-    [Throws=Error]
+    [Throws=NimbusError]
     sequence<EnrolledExperiment> get_active_experiments();
 
     // Getter and setter for user's participation in all experiments.
     // Possible values are:
     // * `true`: the user will not enroll in new experiments, and opt out of all exisitng ones.
     // * `false`: experiments proceed as usual.
-    [Throws=Error]
+    [Throws=NimbusError]
     boolean get_global_user_participation();
 
-    [Throws=Error]
+    [Throws=NimbusError]
     sequence<EnrollmentChangeEvent> set_global_user_participation(boolean opt_in);
 
     // Updates the list of experiments from the server.
     // This method is deprecated, in favour of calling `fetch_experiments()` and then
     // `apply_pending_updates()`.
-    [Throws=Error]
+    [Throws=NimbusError]
     sequence<EnrollmentChangeEvent> update_experiments();
 
     // Fetches the list of experiments from the server. This does not affect the list
     // of active experiments or experiment enrolment.
     // Fetched experiments are not applied until `apply_pending_updates()` is called.
-    [Throws=Error]
+    [Throws=NimbusError]
     void fetch_experiments();
 
     // Apply the updated experiments from the last fetch.
     // After calling this, the list of active experiments might change
     // (there might be new experiments, or old experiments might have expired).
-    [Throws=Error]
+    [Throws=NimbusError]
     sequence<EnrollmentChangeEvent> apply_pending_experiments();
 
     // A convenience method for apps to set the experiments from a local source
     // for either testing, or before the first fetch has finished.
     // 
     // Experiments set with this method are not applied until `apply_pending_updates()` is called.
-    [Throws=Error]
+    [Throws=NimbusError]
     void set_experiments_locally(string experiments_json);
 
     // These are test-only functions and should never be exposed to production
@@ -148,11 +148,11 @@ interface NimbusClient {
 
     // Opt in to a specific branch on a specific experiment. Useful for
     // developers to test their app's interaction with the experiment.
-    [Throws=Error]
+    [Throws=NimbusError]
     sequence<EnrollmentChangeEvent> opt_in_with_branch(string experiment_slug, string branch);
 
     // Opt out of a specific experiment.
-    [Throws=Error]
+    [Throws=NimbusError]
     sequence<EnrollmentChangeEvent> opt_out(string experiment_slug);
 
     // Reset internal state in response to application-level telemetry reset.
@@ -169,6 +169,6 @@ interface NimbusClient {
     //    * disqualifying this client out of any active experiments, to avoid submitting
     //      misleading incomplete data.
     //
-    [Throws=Error]
+    [Throws=NimbusError]
     sequence<EnrollmentChangeEvent> reset_telemetry_identifiers(AvailableRandomizationUnits new_randomization_units);
 };

--- a/nimbus/src/persistence.rs
+++ b/nimbus/src/persistence.rs
@@ -4,7 +4,7 @@
 
 //! Our storage abstraction, currently backed by Rkv.
 
-use crate::error::{Error, Result};
+use crate::error::{NimbusError, Result};
 // This uses the lmdb backend for rkv, which is unstable.
 // We use it for now since glean didn't seem to have trouble with it (although
 // it must be noted that the rkv documentation explicitly says "To use rkv in
@@ -169,7 +169,7 @@ impl SingleStore {
                 if let rkv::Value::Json(data) = data {
                     Ok(Some(serde_json::from_str::<T>(data)?))
                 } else {
-                    Err(Error::InvalidPersistedData)
+                    Err(NimbusError::InvalidPersistedData)
                 }
             }
             None => Ok(None),
@@ -336,7 +336,7 @@ impl Database {
                 if let rkv::Value::Json(data) = data {
                     Ok(Some(serde_json::from_str::<T>(data)?))
                 } else {
-                    Err(Error::InvalidPersistedData)
+                    Err(NimbusError::InvalidPersistedData)
                 }
             }
             None => Ok(None),

--- a/nimbus/src/sampling.rs
+++ b/nimbus/src/sampling.rs
@@ -5,7 +5,7 @@
 //! This module implements the sampling logic required to hash,
 //! randomize and pick branches using pre-set ratios.
 
-use crate::error::{Error, Result};
+use crate::error::{NimbusError, Result};
 use sha2::{Digest, Sha256};
 use std::convert::TryInto;
 
@@ -73,7 +73,7 @@ pub(crate) fn bucket_sample<T: serde::Serialize>(
 /// Could return an error if the input couldn't be hashed
 pub(crate) fn ratio_sample<T: serde::Serialize>(input: T, ratios: &[u32]) -> Result<usize> {
     if ratios.is_empty() {
-        return Err(Error::EmptyRatiosError);
+        return Err(NimbusError::EmptyRatiosError);
     }
     let input_hash = hex::encode(truncated_hash(input)?);
     let ratio_total: u32 = ratios.iter().sum();
@@ -144,7 +144,7 @@ fn is_hash_in_bucket(
 /// returns an error if the fraction not within the 0-1 range
 fn fraction_to_key(fraction: f64) -> Result<String> {
     if !(0.0..=1.0).contains(&fraction) {
-        return Err(Error::InvalidFraction);
+        return Err(NimbusError::InvalidFraction);
     }
     let multiplied = (fraction * (2u64.pow(HASH_BITS) - 1) as f64).floor();
     let multiplied = format!("{:x}", multiplied as u64);
@@ -221,7 +221,7 @@ mod tests {
         let ratios = Vec::new();
         let res = ratio_sample(input, &ratios);
         match res.unwrap_err() {
-            Error::EmptyRatiosError => (), // okay,
+            NimbusError::EmptyRatiosError => (), // okay,
             _ => panic!("Should be an empty ratios error!"),
         }
     }

--- a/nimbus/tests/test_get_experiment_branch_by_feature.rs
+++ b/nimbus/tests/test_get_experiment_branch_by_feature.rs
@@ -5,7 +5,7 @@
 // Testing featured-based get_experiment_branch semantics.
 
 mod common;
-use nimbus::error::{Error, Result};
+use nimbus::error::{NimbusError, Result};
 
 #[cfg(feature = "rkv-safe-mode")]
 #[test]
@@ -14,7 +14,7 @@ fn test_feature_before_open() -> Result<()> {
     let client = common::new_test_client("test_feature_before_open")?;
     assert!(matches!(
         client.get_experiment_branch("not_there_feature".to_string()),
-        Err(Error::DatabaseNotReady)
+        Err(NimbusError::DatabaseNotReady)
     ));
     // now initialize the DB - it should start working (and report no branch)
     client.initialize()?;

--- a/nimbus/tests/test_get_experiment_branch_by_id.rs
+++ b/nimbus/tests/test_get_experiment_branch_by_id.rs
@@ -5,7 +5,7 @@
 // Testing get_experiment_branch semantics.
 
 mod common;
-use nimbus::error::{Error, Result};
+use nimbus::error::{NimbusError, Result};
 
 #[cfg(feature = "rkv-safe-mode")]
 #[test]
@@ -14,7 +14,7 @@ fn test_before_open() -> Result<()> {
     let client = common::new_test_client("test_before_open")?;
     assert!(matches!(
         client.get_experiment_branch("foo".to_string()),
-        Err(Error::DatabaseNotReady)
+        Err(NimbusError::DatabaseNotReady)
     ));
     // now initialize the DB - it should start working (and report no branch)
     client.initialize()?;


### PR DESCRIPTION
This PR prevents collisions between `Error` (from Nimbus) and `Error` from Swift.

The Swift `Error` isn't namespaced, so when compiling the generated swift file, the Nimbus Error is mistaken for the Swift one.

This is split into two implementations: the first commit is the minimally invasive change, using import aliasing.

The second does the actual rename. Reviewers are invited to tell me if I should drop the second commit or not.